### PR TITLE
Update mav2odid code to be compliant with new Mavlink messages

### DIFF
--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -180,7 +180,7 @@ static int m2o_authentication(mav2odid_t *m2o, mavlink_open_drone_id_authenticat
     int size = MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN;
     if (authentication.DataPage == 0)
     {
-        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        size -= ODID_AUTH_PAGE_ZERO_DATA_SIZE;
         authentication.PageCount = mavAuthentication->page_count;
         authentication.Length = mavAuthentication->length;
         authentication.Timestamp = mavAuthentication->timestamp;
@@ -385,7 +385,7 @@ void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
     int size = ODID_STR_SIZE;
     if (Auth->DataPage == 0)
     {
-        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        size -= ODID_AUTH_PAGE_ZERO_DATA_SIZE;
         mavAuth->page_count = Auth->PageCount;
         mavAuth->length = Auth->Length;
         mavAuth->timestamp = Auth->Timestamp;

--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -151,10 +151,10 @@ static int m2o_authentication(mav2odid_t *m2o, mavlink_open_drone_id_authenticat
 /**
 * Convert self ID Mavlink message to encoded Open Drone ID structure
 */
-static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_selfid_t *selfId)
+static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_self_id_t *selfId)
 {
     m2o->selfId.DescType = (ODID_desctype_t) selfId->description_type;
-    for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_SELFID_FIELD_DESCRIPTION_LEN; i++)
+    for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_SELF_ID_FIELD_DESCRIPTION_LEN; i++)
         m2o->selfId.Desc[i] = selfId->description[i];
 
     return encodeSelfIDMessage(&m2o->selfIdEnc, &m2o->selfId);
@@ -166,12 +166,12 @@ static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_selfid_t *selfId)
 static int m2o_system(mav2odid_t *m2o, mavlink_open_drone_id_system_t *system)
 {
     m2o->system.LocationSource = (ODID_location_source_t) system->flags;
-    m2o->system.OperatorLatitude = (float) system->remote_pilot_latitude / 1E7;
-    m2o->system.OperatorLongitude = (float) system->remote_pilot_longitude / 1E7;
-    m2o->system.AreaCount = system->group_count;
-    m2o->system.AreaRadius = system->group_radius;
-    m2o->system.AreaCeiling = system->group_ceiling;
-    m2o->system.AreaFloor = system->group_floor;
+    m2o->system.OperatorLatitude = (float) system->operator_latitude / 1E7;
+    m2o->system.OperatorLongitude = (float) system->operator_longitude / 1E7;
+    m2o->system.AreaCount = system->area_count;
+    m2o->system.AreaRadius = system->area_radius;
+    m2o->system.AreaCeiling = system->area_ceiling;
+    m2o->system.AreaFloor = system->area_floor;
 
     return encodeSystemMessage(&m2o->systemEnc, &m2o->system);
 }
@@ -199,7 +199,7 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
     mavlink_open_drone_id_basic_id_t basicId;
     mavlink_open_drone_id_location_t location;
     mavlink_open_drone_id_authentication_t authentication;
-    mavlink_open_drone_id_selfid_t selfId;
+    mavlink_open_drone_id_self_id_t selfId;
     mavlink_open_drone_id_system_t system;
 
     if (mavlink_parse_char(MAVLINK_COMM_0, data, &message, &status))
@@ -224,8 +224,8 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
                 return ODID_MESSAGETYPE_AUTH;
             break;
 
-        case MAVLINK_MSG_ID_OPEN_DRONE_ID_SELFID:
-            mavlink_msg_open_drone_id_selfid_decode(&message, &selfId);
+        case MAVLINK_MSG_ID_OPEN_DRONE_ID_SELF_ID:
+            mavlink_msg_open_drone_id_self_id_decode(&message, &selfId);
             if (m2o_selfId(m2o, &selfId) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_SELF_ID;
             break;
@@ -249,8 +249,8 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
 void m2o_basicId2Mavlink(mavlink_open_drone_id_basic_id_t *mavBasicId,
                          ODID_BasicID_data *basicId)
 {
-    mavBasicId->id_type = (MAV_ODID_IDTYPE) basicId->IDType;
-    mavBasicId->ua_type = (MAV_ODID_UATYPE) basicId->UAType;
+    mavBasicId->id_type = (MAV_ODID_ID_TYPE) basicId->IDType;
+    mavBasicId->ua_type = (MAV_ODID_UA_TYPE) basicId->UAType;
     for (int i = 0; i < ODID_ID_SIZE; i++)
         mavBasicId->uas_id[i] = basicId->UASID[i];
 }
@@ -285,7 +285,7 @@ void m2o_location2Mavlink(mavlink_open_drone_id_location_t *mavLocation,
 void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
                                 ODID_Auth_data *Auth)
 {
-    mavAuth->authentication_type = (MAV_ODID_AUTH) Auth->AuthType;
+    mavAuth->authentication_type = (MAV_ODID_AUTH_TYPE) Auth->AuthType;
     mavAuth->data_page = Auth->DataPage;
     for (int i = 0; i < ODID_STR_SIZE; i++)
         mavAuth->authentication_data[i] = Auth->AuthData[i];
@@ -294,7 +294,7 @@ void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
 /**
 * Convert non-encoded Open Drone ID self ID structure to Mavlink message
 */
-void m2o_selfId2Mavlink(mavlink_open_drone_id_selfid_t *mavSelfID,
+void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
                         ODID_SelfID_data *selfID)
 {
     mavSelfID->description_type = (MAV_ODID_DESC_TYPE) selfID->DescType;
@@ -309,10 +309,10 @@ void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system)
 {
     mavSystem->flags = (MAV_ODID_LOCATION_SRC) system->LocationSource;
-    mavSystem->remote_pilot_latitude = (int32_t) (system->OperatorLatitude * 1E7);
-    mavSystem->remote_pilot_longitude = (int32_t) (system->OperatorLongitude * 1E7);
-    mavSystem->group_count = system->AreaCount;
-    mavSystem->group_radius = system->AreaRadius;
-    mavSystem->group_ceiling = system->AreaCeiling;
-    mavSystem->group_floor = system->AreaFloor;
+    mavSystem->operator_latitude = (int32_t) (system->OperatorLatitude * 1E7);
+    mavSystem->operator_longitude = (int32_t) (system->OperatorLongitude * 1E7);
+    mavSystem->area_count = system->AreaCount;
+    mavSystem->area_radius = system->AreaRadius;
+    mavSystem->area_ceiling = system->AreaCeiling;
+    mavSystem->area_floor = system->AreaFloor;
 }

--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -44,18 +44,39 @@ int m2o_init(mav2odid_t *m2o)
     m2o->droneidSchedule[6] = ODID_MESSAGETYPE_SYSTEM;
     m2o->droneidSchedule[8] = ODID_MESSAGETYPE_OPERATOR_ID;
 
-    if (encodeBasicIDMessage(&m2o->basicIdEnc, &m2o->basicId))
+    union {
+        ODID_BasicID_data basicId;
+        ODID_Location_data location;
+        ODID_Auth_data auth;
+        ODID_SelfID_data selfId;
+        ODID_System_data system;
+        ODID_OperatorID_data operatorId;
+    } data;
+
+    odid_initBasicIDData(&data.basicId);
+    if (encodeBasicIDMessage(&m2o->basicIdEnc, &data.basicId))
         return ODID_FAIL;
-    if (encodeLocationMessage(&m2o->locationEnc, &m2o->location))
+
+    odid_initLocationData(&data.location);
+    if (encodeLocationMessage(&m2o->locationEnc, &data.location))
         return ODID_FAIL;
-    if (encodeAuthMessage(&m2o->authenticationEnc, &m2o->authentication))
+
+    odid_initAuthData(&data.auth);
+    if (encodeAuthMessage(&m2o->authenticationEnc, &data.auth))
         return ODID_FAIL;
-    if (encodeSelfIDMessage(&m2o->selfIdEnc, &m2o->selfId))
+
+    odid_initSelfIDData(&data.selfId);
+    if (encodeSelfIDMessage(&m2o->selfIdEnc, &data.selfId))
         return ODID_FAIL;
-    if (encodeSystemMessage(&m2o->systemEnc, &m2o->system))
+
+    odid_initSystemData(&data.system);
+    if (encodeSystemMessage(&m2o->systemEnc, &data.system))
         return ODID_FAIL;
-    if (encodeOperatorIDMessage(&m2o->operatorIdEnc, &m2o->operatorId))
+
+    odid_initOperatorIDData(&data.operatorId);
+    if (encodeOperatorIDMessage(&m2o->operatorIdEnc, &data.operatorId))
         return ODID_FAIL;
+
     return ODID_SUCCESS;
 }
 
@@ -110,115 +131,122 @@ int m2o_cycleMessages(mav2odid_t *m2o, uint8_t *data)
 /**
 * Convert a basic ID Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_basicId(mav2odid_t *m2o, mavlink_open_drone_id_basic_id_t *basicId)
+static int m2o_basicId(mav2odid_t *m2o, mavlink_open_drone_id_basic_id_t *mavBasicId)
 {
-    m2o->basicId.IDType = (ODID_idtype_t) basicId->id_type;
-    m2o->basicId.UAType = (ODID_uatype_t) basicId->ua_type;
+    ODID_BasicID_data basicId;
+    basicId.IDType = (ODID_idtype_t) mavBasicId->id_type;
+    basicId.UAType = (ODID_uatype_t) mavBasicId->ua_type;
     for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_BASIC_ID_FIELD_UAS_ID_LEN; i++)
-        m2o->basicId.UASID[i] = basicId->uas_id[i];
+        basicId.UASID[i] = mavBasicId->uas_id[i];
 
-    return encodeBasicIDMessage(&m2o->basicIdEnc, &m2o->basicId);
+    return encodeBasicIDMessage(&m2o->basicIdEnc, &basicId);
 }
 
 /**
 * Convert a location Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_location(mav2odid_t *m2o, mavlink_open_drone_id_location_t *location)
+static int m2o_location(mav2odid_t *m2o, mavlink_open_drone_id_location_t *mavLocation)
 {
-    m2o->location.Status = (ODID_status_t) location->status;
-    m2o->location.Direction = (float) location->direction / 100;
-    m2o->location.SpeedHorizontal = (float) location->speed_horizontal / 100;
-    m2o->location.SpeedVertical = (float) location->speed_vertical / 100;
-    m2o->location.Latitude = (float) location->latitude / 1E7;
-    m2o->location.Longitude = (float) location->longitude / 1E7;
-    m2o->location.AltitudeBaro = location->altitude_barometric;
-    m2o->location.AltitudeGeo = location->altitude_geodetic;
-    m2o->location.HeightType = (ODID_Height_reference_t) location->height_reference;
-    m2o->location.Height = location->height;
-    m2o->location.HorizAccuracy = (ODID_Horizontal_accuracy_t) location->horizontal_accuracy;
-    m2o->location.VertAccuracy = (ODID_Vertical_accuracy_t) location->vertical_accuracy;
-    m2o->location.BaroAccuracy = (ODID_Vertical_accuracy_t) location->barometer_accuracy;
-    m2o->location.SpeedAccuracy = (ODID_Speed_accuracy_t) location->speed_accuracy;
-    m2o->location.TSAccuracy = (ODID_Timestamp_accuracy_t) location->timestamp_accuracy;
-    m2o->location.TimeStamp = location->timestamp;
+    ODID_Location_data location;
+    location.Status = (ODID_status_t) mavLocation->status;
+    location.Direction = (float) mavLocation->direction / 100;
+    location.SpeedHorizontal = (float) mavLocation->speed_horizontal / 100;
+    location.SpeedVertical = (float) mavLocation->speed_vertical / 100;
+    location.Latitude = (float) mavLocation->latitude / 1E7;
+    location.Longitude = (float) mavLocation->longitude / 1E7;
+    location.AltitudeBaro = mavLocation->altitude_barometric;
+    location.AltitudeGeo = mavLocation->altitude_geodetic;
+    location.HeightType = (ODID_Height_reference_t) mavLocation->height_reference;
+    location.Height = mavLocation->height;
+    location.HorizAccuracy = (ODID_Horizontal_accuracy_t) mavLocation->horizontal_accuracy;
+    location.VertAccuracy = (ODID_Vertical_accuracy_t) mavLocation->vertical_accuracy;
+    location.BaroAccuracy = (ODID_Vertical_accuracy_t) mavLocation->barometer_accuracy;
+    location.SpeedAccuracy = (ODID_Speed_accuracy_t) mavLocation->speed_accuracy;
+    location.TSAccuracy = (ODID_Timestamp_accuracy_t) mavLocation->timestamp_accuracy;
+    location.TimeStamp = mavLocation->timestamp;
 
-    return encodeLocationMessage(&m2o->locationEnc, &m2o->location);
+    return encodeLocationMessage(&m2o->locationEnc, &location);
 }
 
 /**
 * Convert an authentication Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_authentication(mav2odid_t *m2o, mavlink_open_drone_id_authentication_t *authentication)
+static int m2o_authentication(mav2odid_t *m2o, mavlink_open_drone_id_authentication_t *mavAuthentication)
 {
-    m2o->authentication.DataPage = authentication->data_page;
-    m2o->authentication.AuthType = (ODID_authtype_t) authentication->authentication_type;
+    ODID_Auth_data authentication;
+    authentication.DataPage = mavAuthentication->data_page;
+    authentication.AuthType = (ODID_authtype_t) mavAuthentication->authentication_type;
 
     int size = MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN;
-    if (authentication->data_page == 0)
+    if (authentication.DataPage == 0)
     {
         size -= ODID_AUTH_PAGE_0_DATA_SIZE;
-        m2o->authentication.PageCount = authentication->page_count;
-        m2o->authentication.Length = authentication->length;
-        m2o->authentication.Timestamp = authentication->timestamp;
+        authentication.PageCount = mavAuthentication->page_count;
+        authentication.Length = mavAuthentication->length;
+        authentication.Timestamp = mavAuthentication->timestamp;
     }
 
     for (int i = 0; i < size; i++)
-        m2o->authentication.AuthData[i] = authentication->authentication_data[i];
+        authentication.AuthData[i] = mavAuthentication->authentication_data[i];
 
-    return encodeAuthMessage(&m2o->authenticationEnc, &m2o->authentication);
+    return encodeAuthMessage(&m2o->authenticationEnc, &authentication);
 }
 
 /**
 * Convert a self ID Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_self_id_t *selfId)
+static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_self_id_t *mavSelfId)
 {
-    m2o->selfId.DescType = (ODID_desctype_t) selfId->description_type;
+    ODID_SelfID_data selfId;
+    selfId.DescType = (ODID_desctype_t) mavSelfId->description_type;
     for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_SELF_ID_FIELD_DESCRIPTION_LEN; i++)
-        m2o->selfId.Desc[i] = selfId->description[i];
+        selfId.Desc[i] = mavSelfId->description[i];
 
-    return encodeSelfIDMessage(&m2o->selfIdEnc, &m2o->selfId);
+    return encodeSelfIDMessage(&m2o->selfIdEnc, &selfId);
 }
 
 /**
 * Convert a system Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_system(mav2odid_t *m2o, mavlink_open_drone_id_system_t *system)
+static int m2o_system(mav2odid_t *m2o, mavlink_open_drone_id_system_t *mavSystem)
 {
-    m2o->system.LocationSource = (ODID_location_source_t) system->flags;
-    m2o->system.OperatorLatitude = (float) system->operator_latitude / 1E7;
-    m2o->system.OperatorLongitude = (float) system->operator_longitude / 1E7;
-    m2o->system.AreaCount = system->area_count;
-    m2o->system.AreaRadius = system->area_radius;
-    m2o->system.AreaCeiling = system->area_ceiling;
-    m2o->system.AreaFloor = system->area_floor;
+    ODID_System_data system;
+    system.LocationSource = (ODID_location_source_t) mavSystem->flags;
+    system.OperatorLatitude = (float) mavSystem->operator_latitude / 1E7;
+    system.OperatorLongitude = (float) mavSystem->operator_longitude / 1E7;
+    system.AreaCount = mavSystem->area_count;
+    system.AreaRadius = mavSystem->area_radius;
+    system.AreaCeiling = mavSystem->area_ceiling;
+    system.AreaFloor = mavSystem->area_floor;
 
-    return encodeSystemMessage(&m2o->systemEnc, &m2o->system);
+    return encodeSystemMessage(&m2o->systemEnc, &system);
 }
 
 /**
 * Convert an operator ID Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_operatorId(mav2odid_t *m2o, mavlink_open_drone_id_operator_id_t *operatorId)
+static int m2o_operatorId(mav2odid_t *m2o, mavlink_open_drone_id_operator_id_t *mavOperatorId)
 {
-    m2o->operatorId.OperatorIdType = (ODID_operatorIdType_t) operatorId->operator_id_type;
+    ODID_OperatorID_data operatorId;
+    operatorId.OperatorIdType = (ODID_operatorIdType_t) mavOperatorId->operator_id_type;
     for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_OPERATOR_ID_FIELD_OPERATOR_ID_LEN; i++)
-        m2o->operatorId.OperatorId[i] = operatorId->operator_id[i];
+        operatorId.OperatorId[i] = mavOperatorId->operator_id[i];
 
-    return encodeOperatorIDMessage(&m2o->operatorIdEnc, &m2o->operatorId);
+    return encodeOperatorIDMessage(&m2o->operatorIdEnc, &operatorId);
 }
 
 /**
 * Convert a message pack Mavlink message to an encoded Open Drone ID structure
 */
-static int m2o_messagePack(mav2odid_t *m2o, mavlink_open_drone_id_message_pack_t *messagePack)
+static int m2o_messagePack(mav2odid_t *m2o, mavlink_open_drone_id_message_pack_t *mavMessagePack)
 {
-    m2o->messagePack.SingleMessageSize = messagePack->single_message_size;
-    m2o->messagePack.MsgPackSize = messagePack->msg_pack_size;
-    for (int i = 0; i < messagePack->msg_pack_size; i++)
+    ODID_MessagePack_data messagePack;
+    messagePack.SingleMessageSize = mavMessagePack->single_message_size;
+    messagePack.MsgPackSize = mavMessagePack->msg_pack_size;
+    for (int i = 0; i < mavMessagePack->msg_pack_size; i++)
         for (int j = 0; j < ODID_MESSAGE_SIZE; j++)
-            m2o->messagePack.Messages[i].rawData[j] = messagePack->messages[i*ODID_MESSAGE_SIZE + j];
-    return encodeMessagePack(&m2o->messagePackEnc, &m2o->messagePack);
+            messagePack.Messages[i].rawData[j] = mavMessagePack->messages[i*ODID_MESSAGE_SIZE + j];
+    return encodeMessagePack(&m2o->messagePackEnc, &messagePack);
 }
 
 /**
@@ -239,15 +267,21 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
     if (!m2o)
         return ODID_MESSAGETYPE_INVALID;
 
+    union {
+        mavlink_open_drone_id_basic_id_t basicId;
+        mavlink_open_drone_id_location_t location;
+        mavlink_open_drone_id_authentication_t authentication;
+        mavlink_open_drone_id_self_id_t selfId;
+        mavlink_open_drone_id_system_t system;
+        mavlink_open_drone_id_operator_id_t operatorId;
+        mavlink_open_drone_id_message_pack_t messagePack;
+    } msg;
     mavlink_message_t message;
+
+    // Note: this struct can in principle be set to null, to reduce stack usage.
+    // The code in mavlink_helpers.h will not write to it, if it has not been
+    // allocated and this parse function does not need the status information.
     mavlink_status_t status;
-    mavlink_open_drone_id_basic_id_t basicId;
-    mavlink_open_drone_id_location_t location;
-    mavlink_open_drone_id_authentication_t authentication;
-    mavlink_open_drone_id_self_id_t selfId;
-    mavlink_open_drone_id_system_t system;
-    mavlink_open_drone_id_operator_id_t operatorId;
-    mavlink_open_drone_id_message_pack_t messagePack;
 
     // Enhance this, if used in a system transmitting on other than channel 0
     if (mavlink_parse_char(MAVLINK_COMM_0, data, &message, &status))
@@ -255,44 +289,44 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
         switch (message.msgid)
         {
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID:
-            mavlink_msg_open_drone_id_basic_id_decode(&message, &basicId);
-            if (m2o_basicId(m2o, &basicId) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_basic_id_decode(&message, &msg.basicId);
+            if (m2o_basicId(m2o, &msg.basicId) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_BASIC_ID;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_LOCATION:
-            mavlink_msg_open_drone_id_location_decode(&message, &location);
-            if (m2o_location(m2o, &location) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_location_decode(&message, &msg.location);
+            if (m2o_location(m2o, &msg.location) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_LOCATION;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_AUTHENTICATION:
-            mavlink_msg_open_drone_id_authentication_decode(&message, &authentication);
-            if (m2o_authentication(m2o, &authentication) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_authentication_decode(&message, &msg.authentication);
+            if (m2o_authentication(m2o, &msg.authentication) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_AUTH;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_SELF_ID:
-            mavlink_msg_open_drone_id_self_id_decode(&message, &selfId);
-            if (m2o_selfId(m2o, &selfId) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_self_id_decode(&message, &msg.selfId);
+            if (m2o_selfId(m2o, &msg.selfId) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_SELF_ID;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_SYSTEM:
-            mavlink_msg_open_drone_id_system_decode(&message, &system);
-            if (m2o_system(m2o, &system) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_system_decode(&message, &msg.system);
+            if (m2o_system(m2o, &msg.system) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_SYSTEM;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_OPERATOR_ID:
-            mavlink_msg_open_drone_id_operator_id_decode(&message, &operatorId);
-            if (m2o_operatorId(m2o, &operatorId) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_operator_id_decode(&message, &msg.operatorId);
+            if (m2o_operatorId(m2o, &msg.operatorId) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_OPERATOR_ID;
             break;
 
         case MAVLINK_MSG_ID_OPEN_DRONE_ID_MESSAGE_PACK:
-            mavlink_msg_open_drone_id_message_pack_decode(&message, &messagePack);
-            if (m2o_messagePack(m2o, &messagePack) == ODID_SUCCESS)
+            mavlink_msg_open_drone_id_message_pack_decode(&message, &msg.messagePack);
+            if (m2o_messagePack(m2o, &msg.messagePack) == ODID_SUCCESS)
                 return ODID_MESSAGETYPE_PACKED;
             break;
 
@@ -304,7 +338,7 @@ ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data)
 }
 
 /**
-* Convert non-encoded Open Drone ID basic ID structure to Mavlink message
+* Convert a non-encoded Open Drone ID basic ID structure to a Mavlink message
 */
 void m2o_basicId2Mavlink(mavlink_open_drone_id_basic_id_t *mavBasicId,
                          ODID_BasicID_data *basicId)
@@ -316,7 +350,7 @@ void m2o_basicId2Mavlink(mavlink_open_drone_id_basic_id_t *mavBasicId,
 }
 
 /**
-* Convert non-encoded Open Drone ID basic ID structure to Mavlink message
+* Convert a non-encoded Open Drone ID basic ID structure to a Mavlink message
 */
 void m2o_location2Mavlink(mavlink_open_drone_id_location_t *mavLocation,
                           ODID_Location_data *location)
@@ -340,7 +374,7 @@ void m2o_location2Mavlink(mavlink_open_drone_id_location_t *mavLocation,
 }
 
 /**
-* Convert non-encoded Open Drone ID authentication structure to Mavlink message
+* Convert a non-encoded Open Drone ID authentication structure to a Mavlink message
 */
 void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
                                 ODID_Auth_data *Auth)
@@ -362,7 +396,7 @@ void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
 }
 
 /**
-* Convert non-encoded Open Drone ID self ID structure to Mavlink message
+* Convert a non-encoded Open Drone ID self ID structure to a Mavlink message
 */
 void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
                         ODID_SelfID_data *selfID)
@@ -373,7 +407,7 @@ void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
 }
 
 /**
-* Convert non-encoded Open Drone ID system structure to Mavlink message
+* Convert a non-encoded Open Drone ID system structure to a Mavlink message
 */
 void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system)
@@ -388,7 +422,7 @@ void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
 }
 
 /**
-* Convert non-encoded Open Drone ID operator ID structure to Mavlink message
+* Convert a non-encoded Open Drone ID operator ID structure to a Mavlink message
 */
 void m2o_operatorId2Mavlink(mavlink_open_drone_id_operator_id_t *mavOperatorID,
                             ODID_OperatorID_data *operatorID)
@@ -399,7 +433,7 @@ void m2o_operatorId2Mavlink(mavlink_open_drone_id_operator_id_t *mavOperatorID,
 }
 
 /**
-* Convert non-encoded Open Drone ID message pack structure to Mavlink message
+* Convert a non-encoded Open Drone ID message pack structure to a Mavlink message
 */
 void m2o_messagePack2Mavlink(mavlink_open_drone_id_message_pack_t *mavMessagePack,
                              ODID_MessagePack_data *messagePack)

--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -148,7 +148,17 @@ static int m2o_authentication(mav2odid_t *m2o, mavlink_open_drone_id_authenticat
 {
     m2o->authentication.DataPage = authentication->data_page;
     m2o->authentication.AuthType = (ODID_authtype_t) authentication->authentication_type;
-    for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN; i++)
+
+    int size = MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN;
+    if (authentication->data_page == 0)
+    {
+        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        m2o->authentication.PageCount = authentication->page_count;
+        m2o->authentication.Length = authentication->length;
+        m2o->authentication.Timestamp = authentication->timestamp;
+    }
+
+    for (int i = 0; i < size; i++)
         m2o->authentication.AuthData[i] = authentication->authentication_data[i];
 
     return encodeAuthMessage(&m2o->authenticationEnc, &m2o->authentication);
@@ -312,7 +322,17 @@ void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
 {
     mavAuth->authentication_type = (MAV_ODID_AUTH_TYPE) Auth->AuthType;
     mavAuth->data_page = Auth->DataPage;
-    for (int i = 0; i < ODID_STR_SIZE; i++)
+
+    int size = ODID_STR_SIZE;
+    if (Auth->DataPage == 0)
+    {
+        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        mavAuth->page_count = Auth->PageCount;
+        mavAuth->length = Auth->Length;
+        mavAuth->timestamp = Auth->Timestamp;
+    }
+
+    for (int i = 0; i < size; i++)
         mavAuth->authentication_data[i] = Auth->AuthData[i];
 }
 

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -61,6 +61,8 @@ typedef struct {
 
 int m2o_init(mav2odid_t *m2o);
 int m2o_cycleMessages(mav2odid_t *m2o, uint8_t *data);
+int m2o_collectMessagePack(mav2odid_t *m2o);
+
 ODID_messagetype_t m2o_parseMavlink(mav2odid_t *m2o, uint8_t data);
 
 void m2o_basicId2Mavlink(mavlink_open_drone_id_basic_id_t *mavBasicId,

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -54,6 +54,8 @@ typedef struct {
     ODID_System_encoded systemEnc;
     ODID_OperatorID_data operatorId;
     ODID_OperatorID_encoded operatorIdEnc;
+    ODID_MessagePack_data messagePack;
+    ODID_MessagePack_encoded messagePackEnc;
 } mav2odid_t;
 
 int m2o_init(mav2odid_t *m2o);
@@ -72,5 +74,7 @@ void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system);
 void m2o_operatorId2Mavlink(mavlink_open_drone_id_operator_id_t *mavOperatorID,
                             ODID_OperatorID_data *operatorID);
+void m2o_messagePack2Mavlink(mavlink_open_drone_id_message_pack_t *mavMessagePack,
+                             ODID_MessagePack_data *messagePack);
 
 #endif /* _MAV2ODID_H_ */

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -36,7 +36,7 @@ mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 
 #include <common/mavlink.h>
 
-#define DRONEID_SCHEDULER_SIZE 8
+#define DRONEID_SCHEDULER_SIZE 10
 
 typedef struct {
     uint8_t droneidSchedule[DRONEID_SCHEDULER_SIZE];
@@ -52,6 +52,8 @@ typedef struct {
     ODID_SelfID_encoded selfIdEnc;
     ODID_System_data system;
     ODID_System_encoded systemEnc;
+    ODID_OperatorID_data operatorId;
+    ODID_OperatorID_encoded operatorIdEnc;
 } mav2odid_t;
 
 int m2o_init(mav2odid_t *m2o);
@@ -68,5 +70,7 @@ void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
                         ODID_SelfID_data *selfID);
 void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system);
+void m2o_operatorId2Mavlink(mavlink_open_drone_id_operator_id_t *mavOperatorID,
+                            ODID_OperatorID_data *operatorID);
 
 #endif /* _MAV2ODID_H_ */

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -64,7 +64,7 @@ void m2o_location2Mavlink(mavlink_open_drone_id_location_t *mavLocation,
                           ODID_Location_data *location);
 void m2o_authentication2Mavlink(mavlink_open_drone_id_authentication_t *mavAuth,
                                 ODID_Auth_data *Auth);
-void m2o_selfId2Mavlink(mavlink_open_drone_id_selfid_t *mavSelfID,
+void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
                         ODID_SelfID_data *selfID);
 void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system);

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -36,7 +36,7 @@ mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 
 #include <common/mavlink.h>
 
-#define DRONEID_SCHEDULER_SIZE 10
+#define DRONEID_SCHEDULER_SIZE 18
 
 typedef struct {
     uint8_t droneidSchedule[DRONEID_SCHEDULER_SIZE];
@@ -44,11 +44,19 @@ typedef struct {
 
     ODID_BasicID_encoded basicIdEnc;
     ODID_Location_encoded locationEnc;
-    ODID_Auth_encoded authenticationEnc;
+    ODID_Auth_encoded authEnc[ODID_AUTH_MAX_PAGES];
     ODID_SelfID_encoded selfIdEnc;
     ODID_System_encoded systemEnc;
     ODID_OperatorID_encoded operatorIdEnc;
     ODID_MessagePack_encoded messagePackEnc;
+
+    uint8_t basicIDEncValid;
+    uint8_t locationEncValid;
+    uint8_t authEncValid[ODID_AUTH_MAX_PAGES];
+    uint8_t selfIDEncValid;
+    uint8_t systemEncValid;
+    uint8_t operatorIDEncValid;
+    uint8_t messagePackEncValid;
 } mav2odid_t;
 
 int m2o_init(mav2odid_t *m2o);

--- a/libmav2odid/mav2odid.h
+++ b/libmav2odid/mav2odid.h
@@ -42,19 +42,12 @@ typedef struct {
     uint8_t droneidSchedule[DRONEID_SCHEDULER_SIZE];
     uint8_t scheduleIdx;
 
-    ODID_BasicID_data basicId;
     ODID_BasicID_encoded basicIdEnc;
-    ODID_Location_data location;
     ODID_Location_encoded locationEnc;
-    ODID_Auth_data authentication;
     ODID_Auth_encoded authenticationEnc;
-    ODID_SelfID_data selfId;
     ODID_SelfID_encoded selfIdEnc;
-    ODID_System_data system;
     ODID_System_encoded systemEnc;
-    ODID_OperatorID_data operatorId;
     ODID_OperatorID_encoded operatorIdEnc;
-    ODID_MessagePack_data messagePack;
     ODID_MessagePack_encoded messagePackEnc;
 } mav2odid_t;
 

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -29,6 +29,103 @@ static int intRangeMax(int64_t inValue, int startRange, int endRange);
 static int intInRange(int inValue, int startRange, int endRange);
 
 /**
+* Initialize basic ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initBasicIDData(ODID_BasicID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_BasicID_data));
+}
+
+/**
+* Initialize location data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initLocationData(ODID_Location_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_Location_data));
+    data->Direction = 361;
+    data->SpeedHorizontal = 255;
+    data->SpeedVertical = 63;
+    data->AltitudeBaro = -1000;
+    data->AltitudeGeo = -1000;
+    data->Height = -1000;
+}
+
+/**
+* Initialize authorization data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initAuthData(ODID_Auth_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_Auth_data));
+}
+
+/**
+* Initialize self ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+void odid_initSelfIDData(ODID_SelfID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_SelfID_data));
+}
+
+/**
+* Initialize system data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initSystemData(ODID_System_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_System_data));
+    data->AreaCount = 1;
+    data->AreaCeiling = -1000;
+    data->AreaFloor = -1000;
+}
+
+/**
+* Initialize operator ID data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initOperatorIDData(ODID_OperatorID_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_OperatorID_data));
+}
+
+/**
+* Initialize message pack data fields to their default values
+*
+* @param data (non encoded/packed) structure
+*/
+
+void odid_initMessagePackData(ODID_MessagePack_data *data)
+{
+    if (!data)
+        return;
+    memset(data, 0, sizeof(ODID_MessagePack_data));
+    data->SingleMessageSize = ODID_MESSAGE_SIZE;
+}
+
+/**
 * Encode direction as defined by Open Drone ID
 *
 * The encoding method uses 8 bits for the direction in degrees and
@@ -701,6 +798,10 @@ ODID_messagetype_t decodeMessageType(uint8_t byte)
 *
 * This function assumes that msgData points to a buffer conaining all
 * ODID_MESSAGE_SIZE bytes of an Open Drone ID message.
+*
+* The various Valid flags in uasData are set true whenever a message has been
+* decoded and the corresponding data structure has been filled. The caller must
+* clear these flags before calling decodeOpenDroneID().
 *
 * @param uasData    Structure containing buffers for all message data
 * @param msgData    Pointer to a buffer containing a full encoded Open Drone ID

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -1131,10 +1131,13 @@ void printByteArray(uint8_t *byteArray, uint16_t asize, int spaced)
 */
 void printBasicID_data(ODID_BasicID_data *BasicID)
 {
+    // Ensure the ID is null-terminated
+    char buf[ODID_ID_SIZE + 1] = { 0 };
+    memcpy(buf, BasicID->UASID, ODID_ID_SIZE);
+
     const char ODID_BasicID_data_format[] =
         "UAType: %d\nIDType: %d\nUASID: %s\n";
-    printf(ODID_BasicID_data_format, BasicID->IDType, BasicID->UAType,
-        BasicID->UASID);
+    printf(ODID_BasicID_data_format, BasicID->IDType, BasicID->UAType, buf);
 }
 
 /**
@@ -1170,16 +1173,20 @@ void printAuth_data(ODID_Auth_data *Auth)
 {
     if (Auth->DataPage == 0) {
         const char ODID_Auth_data_format[] =
-            "AuthType: %d\nDataPage: %d\nPageCount: %d\nLenght: %d\nTimestamp:"\
-            " %d\nAuthData: %s\n";
+            "AuthType: %d\nDataPage: %d\nPageCount: %d\nLength: %d\nTimestamp:"\
+            " %d\nAuthData: ";
         printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage,
-            Auth->PageCount, Auth->Length, Auth->Timestamp, Auth->AuthData);
+            Auth->PageCount, Auth->Length, Auth->Timestamp);
+        for (int i = 0; i < ODID_STR_SIZE - ODID_AUTH_PAGE_0_DATA_SIZE; i++)
+            printf("0x%02X ", Auth->AuthData[i]);
     } else {
         const char ODID_Auth_data_format[] =
-            "AuthType: %d\nDataPage: %d\nAuthData: %s\n";
-        printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage,
-            Auth->AuthData);
+            "AuthType: %d\nDataPage: %d\nAuthData: ";
+        printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage);
+        for (int i = 0; i < ODID_STR_SIZE; i++)
+            printf("0x%02X ", Auth->AuthData[i]);
     }
+    printf("\n");
 }
 
 /**
@@ -1189,8 +1196,12 @@ void printAuth_data(ODID_Auth_data *Auth)
 */
 void printSelfID_data(ODID_SelfID_data *SelfID)
 {
+    // Ensure the description is null-terminated
+    char buf[ODID_STR_SIZE + 1] = { 0 };
+    memcpy(buf, SelfID->Desc, ODID_STR_SIZE);
+
     const char ODID_SelfID_data_format[] = "DescType: %d\nDesc: %s\n";
-    printf(ODID_SelfID_data_format, SelfID->DescType, SelfID->Desc);
+    printf(ODID_SelfID_data_format, SelfID->DescType, buf);
 }
 
 /**
@@ -1215,8 +1226,13 @@ void printSystem_data(ODID_System_data *System_data)
 */
 void printOperatorID_data(ODID_OperatorID_data *operatorID)
 {
-    const char ODID_OperatorID_data_format[] = "OperatorIdType: %d\nOperatorId: %s\n";
-    printf(ODID_OperatorID_data_format, operatorID->OperatorIdType, operatorID->OperatorId);
+    // Ensure the ID is null-terminated
+    char buf[ODID_ID_SIZE + 1] = { 0 };
+    memcpy(buf, operatorID->OperatorId, ODID_ID_SIZE);
+
+    const char ODID_OperatorID_data_format[] =
+        "OperatorIdType: %d\nOperatorId: %s\n";
+    printf(ODID_OperatorID_data_format, operatorID->OperatorIdType, buf);
 }
 
 #endif // ODID_DISABLE_PRINTF

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -353,10 +353,14 @@ static int checkPackContent(ODID_Messages_encoded *msgs, int amount)
     }
 
     // Allow max one of each message except Authorization, of which there can
-    // be five. The OpenDroneID specification is slightly less restrictive but
-    // this implementation does not support anything else
-    if (numMessages[0] > 1 || numMessages[1] > 1 || numMessages[2] > 5 ||
-        numMessages[3] > 1 || numMessages[4] > 1 || numMessages[5] > 1)
+    // be ODID_AUTH_MAX_PAGES. The OpenDroneID specification is slightly less
+    // restrictive but this implementation does not support anything else
+    if (numMessages[ODID_MESSAGETYPE_BASIC_ID] > 1 ||
+        numMessages[ODID_MESSAGETYPE_LOCATION] > 1 ||
+        numMessages[ODID_MESSAGETYPE_AUTH] > ODID_AUTH_MAX_PAGES ||
+        numMessages[ODID_MESSAGETYPE_SELF_ID] > 1 ||
+        numMessages[ODID_MESSAGETYPE_SYSTEM] > 1 ||
+        numMessages[ODID_MESSAGETYPE_OPERATOR_ID] > 1)
         return ODID_FAIL;
 
     return ODID_SUCCESS;

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -347,10 +347,10 @@ int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData)
     if (inData->DataPage >= ODID_AUTH_MAX_PAGES)
         return ODID_FAIL;
 
-    outEncoded->page_0.MessageType = ODID_MESSAGETYPE_AUTH;
-    outEncoded->page_0.ProtoVersion = ODID_PROTOCOL_VERSION;
-    outEncoded->page_0.AuthType = inData->AuthType;
-    outEncoded->page_0.DataPage = inData->DataPage;
+    outEncoded->page_zero.MessageType = ODID_MESSAGETYPE_AUTH;
+    outEncoded->page_zero.ProtoVersion = ODID_PROTOCOL_VERSION;
+    outEncoded->page_zero.AuthType = inData->AuthType;
+    outEncoded->page_zero.DataPage = inData->DataPage;
     if (inData->DataPage == 0) {
         if (inData->PageCount > ODID_AUTH_MAX_PAGES)
             return ODID_FAIL;
@@ -358,14 +358,14 @@ int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData)
         if (inData->Length > MAX_AUTH_LENGTH)
             return ODID_FAIL;
 
-        outEncoded->page_0.PageCount = inData->PageCount;
-        outEncoded->page_0.Length = inData->Length;
-        outEncoded->page_0.Timestamp = inData->Timestamp;
-        strncpy(outEncoded->page_0.AuthData, inData->AuthData,
-                sizeof(outEncoded->page_0.AuthData));
+        outEncoded->page_zero.PageCount = inData->PageCount;
+        outEncoded->page_zero.Length = inData->Length;
+        outEncoded->page_zero.Timestamp = inData->Timestamp;
+        strncpy(outEncoded->page_zero.AuthData, inData->AuthData,
+                sizeof(outEncoded->page_zero.AuthData));
     } else {
-        strncpy(outEncoded->page_1_4.AuthData, inData->AuthData,
-                sizeof(outEncoded->page_1_4.AuthData));
+        strncpy(outEncoded->page_non_zero.AuthData, inData->AuthData,
+                sizeof(outEncoded->page_non_zero.AuthData));
     }
     return ODID_SUCCESS;
 }
@@ -662,12 +662,12 @@ int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *in
 int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum)
 {
     if (!inEncoded ||
-        inEncoded->page_0.MessageType != ODID_MESSAGETYPE_AUTH ||
-        !intInRange(inEncoded->page_0.AuthType, 0, 15) ||
-        !intInRange(inEncoded->page_0.DataPage, 0, 4))
+        inEncoded->page_zero.MessageType != ODID_MESSAGETYPE_AUTH ||
+        !intInRange(inEncoded->page_zero.AuthType, 0, 15) ||
+        !intInRange(inEncoded->page_zero.DataPage, 0, 4))
         return ODID_FAIL;
 
-    *pageNum = inEncoded->page_0.DataPage;
+    *pageNum = inEncoded->page_zero.DataPage;
     return ODID_SUCCESS;
 }
 
@@ -681,21 +681,21 @@ int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum)
 int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
-        inEncoded->page_0.MessageType != ODID_MESSAGETYPE_AUTH ||
-        !intInRange(inEncoded->page_0.AuthType, 0, 15) ||
-        !intInRange(inEncoded->page_0.DataPage, 0, 4))
+        inEncoded->page_zero.MessageType != ODID_MESSAGETYPE_AUTH ||
+        !intInRange(inEncoded->page_zero.AuthType, 0, 15) ||
+        !intInRange(inEncoded->page_zero.DataPage, 0, 4))
         return ODID_FAIL;
 
-    outData->AuthType = (ODID_authtype_t) inEncoded->page_0.AuthType;
-    outData->DataPage = inEncoded->page_0.DataPage;
-    if (inEncoded->page_0.DataPage == 0) {
-        outData->PageCount = inEncoded->page_0.PageCount;
-        outData->Length = inEncoded->page_0.Length;
-        outData->Timestamp = inEncoded->page_0.Timestamp;
-        safe_dec_copyfill(outData->AuthData, inEncoded->page_0.AuthData,
-                          sizeof(outData->AuthData) - ODID_AUTH_PAGE_0_DATA_SIZE);
+    outData->AuthType = (ODID_authtype_t) inEncoded->page_zero.AuthType;
+    outData->DataPage = inEncoded->page_zero.DataPage;
+    if (inEncoded->page_zero.DataPage == 0) {
+        outData->PageCount = inEncoded->page_zero.PageCount;
+        outData->Length = inEncoded->page_zero.Length;
+        outData->Timestamp = inEncoded->page_zero.Timestamp;
+        safe_dec_copyfill(outData->AuthData, inEncoded->page_zero.AuthData,
+                          sizeof(outData->AuthData) - ODID_AUTH_PAGE_ZERO_DATA_SIZE);
     } else {
-        safe_dec_copyfill(outData->AuthData, inEncoded->page_1_4.AuthData,
+        safe_dec_copyfill(outData->AuthData, inEncoded->page_non_zero.AuthData,
                           sizeof(outData->AuthData));
     }
     return ODID_SUCCESS;
@@ -1303,7 +1303,7 @@ void printAuth_data(ODID_Auth_data *Auth)
             " %d\nAuthData: ";
         printf(ODID_Auth_data_format, Auth->AuthType, Auth->DataPage,
             Auth->PageCount, Auth->Length, Auth->Timestamp);
-        for (int i = 0; i < ODID_STR_SIZE - ODID_AUTH_PAGE_0_DATA_SIZE; i++)
+        for (int i = 0; i < ODID_STR_SIZE - ODID_AUTH_PAGE_ZERO_DATA_SIZE; i++)
             printf("0x%02X ", Auth->AuthData[i]);
     } else {
         const char ODID_Auth_data_format[] =

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -20,7 +20,7 @@ gabriel.c.cox@intel.com
 #define ODID_PROTOCOL_VERSION 0
 #define ODID_SPEC_VERSION 0.8
 #define ODID_AUTH_MAX_PAGES 5
-#define ODID_AUTH_PAGE_0_DATA_SIZE 6
+#define ODID_AUTH_PAGE_ZERO_DATA_SIZE 6
 #define ODID_PACK_MAX_MESSAGES 10
 
 #define ODID_SUCCESS    0
@@ -41,7 +41,7 @@ gabriel.c.cox@intel.com
 #define MAX_ALT         31767.5 // Maximum altitude
 #define INV_ALT         MIN_ALT // Invalid altitude
 #define MAX_TIMESTAMP   (60 * 60 * 10)
-#define MAX_AUTH_LENGTH ((ODID_STR_SIZE - ODID_AUTH_PAGE_0_DATA_SIZE) + \
+#define MAX_AUTH_LENGTH ((ODID_STR_SIZE - ODID_AUTH_PAGE_ZERO_DATA_SIZE) + \
                          ODID_STR_SIZE * (ODID_AUTH_MAX_PAGES - 1))
 #define MAX_AREA_RADIUS 2550
 
@@ -341,8 +341,8 @@ typedef struct __attribute__((__packed__)) {
     uint32_t Timestamp;
 
     // Byte 8-24
-    char AuthData[ODID_STR_SIZE - ODID_AUTH_PAGE_0_DATA_SIZE];
-} ODID_Auth_encoded_page_0;
+    char AuthData[ODID_STR_SIZE - ODID_AUTH_PAGE_ZERO_DATA_SIZE];
+} ODID_Auth_encoded_page_zero;
 
 typedef struct __attribute__((__packed__)) {
     // Byte 0 [MessageType][ProtoVersion]  -- must define LSb first
@@ -355,11 +355,11 @@ typedef struct __attribute__((__packed__)) {
 
     // Byte 2-24
     char AuthData[ODID_STR_SIZE];
-} ODID_Auth_encoded_page_1_4;
+} ODID_Auth_encoded_page_non_zero;
 
 typedef union {
-    ODID_Auth_encoded_page_0 page_0;
-    ODID_Auth_encoded_page_1_4 page_1_4;
+    ODID_Auth_encoded_page_zero page_zero;
+    ODID_Auth_encoded_page_non_zero page_non_zero;
 } ODID_Auth_encoded;
 
 typedef struct __attribute__((__packed__)) {

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -433,9 +433,6 @@ typedef struct __attribute__((__packed__)) {
 
     // Byte 3 - 252
     ODID_Messages_encoded Messages[ODID_PACK_MAX_MESSAGES];
-
-    // Byte 253 - 255
-    char Reserved[3];
 } ODID_MessagePack_encoded;
 
 typedef struct {

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -26,6 +26,25 @@ gabriel.c.cox@intel.com
 #define ODID_SUCCESS    0
 #define ODID_FAIL       1
 
+#define MIN_DIR         0       // Minimum direction
+#define MAX_DIR         360     // Maximum direction
+#define INV_DIR         361     // Invalid direction
+#define MIN_SPEED_H     0       // Minimum speed horizontal
+#define MAX_SPEED_H     254.25  // Maximum speed horizontal
+#define INV_SPEED_H     255     // Invalid speed horizontal
+#define MIN_SPEED_V     0       // Minimum speed vertical
+#define MAX_SPEED_V     62      // Maximum speed vertical
+#define INV_SPEED_V     63      // Invalid speed vertical
+#define MIN_LATLON      -180    // Minimum latitude/longitude
+#define MAX_LATLON      180     // Maximum latitude/longitude
+#define MIN_ALT         -1000   // Minimum altitude
+#define MAX_ALT         31767.5 // Maximum altitude
+#define INV_ALT         MIN_ALT // Invalid altitude
+#define MAX_TIMESTAMP   (60 * 60 * 10)
+#define MAX_AUTH_LENGTH ((ODID_STR_SIZE - ODID_AUTH_PAGE_0_DATA_SIZE) + \
+                         ODID_STR_SIZE * (ODID_AUTH_MAX_PAGES - 1))
+#define MAX_AREA_RADIUS 2550
+
 typedef enum ODID_messagetype {
     ODID_MESSAGETYPE_BASIC_ID = 0,
     ODID_MESSAGETYPE_LOCATION = 1,

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -427,6 +427,14 @@ typedef struct {
 } ODID_MessagePack_data;
 
 // API Calls
+void odid_initBasicIDData(ODID_BasicID_data *data);
+void odid_initLocationData(ODID_Location_data *data);
+void odid_initAuthData(ODID_Auth_data *data);
+void odid_initSelfIDData(ODID_SelfID_data *data);
+void odid_initSystemData(ODID_System_data *data);
+void odid_initOperatorIDData(ODID_OperatorID_data *data);
+void odid_initMessagePackData(ODID_MessagePack_data *data);
+
 int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData);
 int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData);
 int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData);

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -51,7 +51,7 @@ static void print_mavlink_auth(mavlink_open_drone_id_authentication_t *auth)
     int size = MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN;
     if (auth->data_page == 0)
     {
-        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        size -= ODID_AUTH_PAGE_ZERO_DATA_SIZE;
         printf("page_count: %d, length: %d, timestamp: %d, ",
                auth->page_count, auth->length, auth->timestamp);
     }
@@ -220,7 +220,7 @@ static void test_authentication(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
         .data_page = 0,
         .authentication_type = MAV_ODID_AUTH_TYPE_UAS_ID_SIGNATURE,
         .authentication_data = "98765432101234567",
-        .page_count = 0,
+        .page_count = 1,
         .length = 17,
         .timestamp = 23000000 };
     printf("\n\n---------------------Authentication---------------------\n\n");

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -49,7 +49,7 @@ static void print_mavlink_auth(mavlink_open_drone_id_authentication_t *auth)
     printf("\n");
 }
 
-static void print_mavlink_selfID(mavlink_open_drone_id_selfid_t *self_id)
+static void print_mavlink_selfID(mavlink_open_drone_id_self_id_t *self_id)
 {
     printf("Type: %d, description: %s\n",
            self_id->description_type, self_id->description);
@@ -59,9 +59,9 @@ static void print_mavlink_system(mavlink_open_drone_id_system_t *system)
 {
     printf("Location Source: %d\nLat/Lon: %d, %d degE7, Area Count, Radius: %d, %d, \n"\
            "Ceiling, Floor: %.2f, %.2f m\n",
-           system->flags, system->remote_pilot_latitude,
-           system->remote_pilot_longitude, system->group_count,
-           system->group_radius, system->group_ceiling, system->group_floor);
+           system->flags, system->operator_latitude,
+           system->operator_longitude, system->area_count,
+           system->area_radius, system->area_ceiling, system->area_floor);
 }
 
 /**
@@ -116,8 +116,8 @@ static void test_basicId(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
 {
     mavlink_message_t msg = { 0 };
     mavlink_open_drone_id_basic_id_t basic_id = {
-        .ua_type = MAV_ODID_UATYPE_ROTORCRAFT,
-        .id_type = MAV_ODID_IDTYPE_SERIAL_NUMBER,
+        .ua_type = MAV_ODID_UA_TYPE_ROTORCRAFT,
+        .id_type = MAV_ODID_ID_TYPE_SERIAL_NUMBER,
         .uas_id = "987654321ABCDEFGHJK" };
 
     printf("\n--------------------------Basic ID------------------------\n\n");
@@ -160,7 +160,7 @@ static void test_location(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
         .horizontal_accuracy = MAV_ODID_HOR_ACC_3_METER,
         .vertical_accuracy = MAV_ODID_VER_ACC_1_METER,
         .barometer_accuracy = MAV_ODID_VER_ACC_3_METER,
-        .speed_accuracy = MAV_ODID_SPEED_ACC_1_METER_PER_SECOND,
+        .speed_accuracy = MAV_ODID_SPEED_ACC_1_METERS_PER_SECOND,
         .timestamp_accuracy = MAV_ODID_TIME_ACC_0_1_SECOND,
         .timestamp = 3243.4f };
 
@@ -192,7 +192,7 @@ static void test_authentication(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
     mavlink_message_t msg = { 0 };
     mavlink_open_drone_id_authentication_t auth = {
         .data_page = 0,
-        .authentication_type = MAV_ODID_AUTH_MPUID,
+        .authentication_type = MAV_ODID_AUTH_TYPE_UAS_ID_SIGNATURE,
         .authentication_data = "987654321" };
     printf("\n\n---------------------Authentication---------------------\n\n");
     print_mavlink_auth(&auth);
@@ -222,16 +222,16 @@ static void test_authentication(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
 static void test_selfID(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
 {
     mavlink_message_t msg = { 0 };
-    mavlink_open_drone_id_selfid_t selfID = {
+    mavlink_open_drone_id_self_id_t selfID = {
         .description_type = MAV_ODID_DESC_TYPE_TEXT,
         .description = "Description of flight" };
 
     printf("\n\n------------------------Self ID------------------------\n\n");
     print_mavlink_selfID(&selfID);
 
-    mavlink_msg_open_drone_id_selfid_encode(MAVLINK_SYSTEM_ID,
-                                            MAVLINK_COMPONENT_ID,
-                                            &msg, &selfID);
+    mavlink_msg_open_drone_id_self_id_encode(MAVLINK_SYSTEM_ID,
+                                             MAVLINK_COMPONENT_ID,
+                                             &msg, &selfID);
 
     ODID_messagetype_t msgType;
     send_parse_tx_rx(m2o, &msg, (uint8_t *) &m2o->selfIdEnc,
@@ -243,7 +243,7 @@ static void test_selfID(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
     printSelfID_data(&uas_data->SelfID);
 
     // The received data is transferred into a Mavlink structure
-    mavlink_open_drone_id_selfid_t selfID2 = { 0 };
+    mavlink_open_drone_id_self_id_t selfID2 = { 0 };
     m2o_selfId2Mavlink(&selfID2, &uas_data->SelfID);
     printf("\n");
     print_mavlink_selfID(&selfID2);
@@ -254,12 +254,12 @@ static void test_system(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
     mavlink_message_t msg = { 0 };
     mavlink_open_drone_id_system_t system = {
         .flags = MAV_ODID_LOCATION_SRC_TAKEOFF,
-        .remote_pilot_latitude = (int32_t) (51.477f * 1E7),
-        .remote_pilot_longitude = (int32_t) (0.0005f * 1E7),
-        .group_count = 350,
-        .group_radius = 55,
-        .group_ceiling = 75.5f,
-        .group_floor = 26.5f };
+        .operator_latitude = (int32_t) (51.477f * 1E7),
+        .operator_longitude = (int32_t) (0.0005f * 1E7),
+        .area_count = 350,
+        .area_radius = 55,
+        .area_ceiling = 75.5f,
+        .area_floor = 26.5f };
 
     printf("\n\n------------------------System------------------------\n\n");
     print_mavlink_system(&system);

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -231,7 +231,7 @@ static void test_authentication(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
                                                     &msg, &auth);
 
     ODID_messagetype_t msgType;
-    send_parse_tx_rx(m2o, &msg, (uint8_t *) &m2o->authenticationEnc,
+    send_parse_tx_rx(m2o, &msg, (uint8_t *) &m2o->authEnc,
                      uas_data, &msgType);
 
     if (msgType != ODID_MESSAGETYPE_AUTH)

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -46,9 +46,17 @@ static void print_mavlink_location(mavlink_open_drone_id_location_t *location)
 
 static void print_mavlink_auth(mavlink_open_drone_id_authentication_t *auth)
 {
-    printf("Data page: %d, auth type: %d, data: ",
+    printf("Data page: %d, auth type: %d, ",
            auth->data_page, auth->authentication_type);
-    for (int i = 0; i < MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN; i++)
+    int size = MAVLINK_MSG_OPEN_DRONE_ID_AUTHENTICATION_FIELD_AUTHENTICATION_DATA_LEN;
+    if (auth->data_page == 0)
+    {
+        size -= ODID_AUTH_PAGE_0_DATA_SIZE;
+        printf("page_count: %d, length: %d, timestamp: %d, ",
+               auth->page_count, auth->length, auth->timestamp);
+    }
+    printf("\n");
+    for (int i = 0; i < size; i++)
         printf("0x%02X ", auth->authentication_data[i]);
     printf("\n");
 }
@@ -211,7 +219,10 @@ static void test_authentication(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
     mavlink_open_drone_id_authentication_t auth = {
         .data_page = 0,
         .authentication_type = MAV_ODID_AUTH_TYPE_UAS_ID_SIGNATURE,
-        .authentication_data = "987654321" };
+        .authentication_data = "98765432101234567",
+        .page_count = 0,
+        .length = 17,
+        .timestamp = 23000000 };
     printf("\n\n---------------------Authentication---------------------\n\n");
     print_mavlink_auth(&auth);
 


### PR DESCRIPTION
The Mavlink messages have been updated to be compliant with v0.8 of the specification.

Update the mav2odid code to match.

Also some minor improvements in various places to the opendroneid code.