### PR TITLE
Support new Classification fields and fix some bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(opendroneid-core C)
 set(VERSION 0.2)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector -fno-delete-null-pointer-checks -fwrapv -O0 -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector \
+    -fno-delete-null-pointer-checks -fwrapv -O0 -Wall -Wdouble-promotion")
 
 cmake_minimum_required(VERSION 2.6.3)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(opendroneid-core C)
 set(VERSION 0.2)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector -fno-delete-null-pointer-checks -fwrapv -O0")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector -fno-delete-null-pointer-checks -fwrapv -O0 -Wall")
 
 cmake_minimum_required(VERSION 2.6.3)
 

--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -217,8 +217,8 @@ static int m2o_location(mav2odid_t *m2o, mavlink_open_drone_id_location_t *mavLo
     location.Direction = (float) mavLocation->direction / 100;
     location.SpeedHorizontal = (float) mavLocation->speed_horizontal / 100;
     location.SpeedVertical = (float) mavLocation->speed_vertical / 100;
-    location.Latitude = (float) mavLocation->latitude / 1E7;
-    location.Longitude = (float) mavLocation->longitude / 1E7;
+    location.Latitude = (double) mavLocation->latitude / 1E7;
+    location.Longitude = (double) mavLocation->longitude / 1E7;
     location.AltitudeBaro = mavLocation->altitude_barometric;
     location.AltitudeGeo = mavLocation->altitude_geodetic;
     location.HeightType = (ODID_Height_reference_t) mavLocation->height_reference;
@@ -289,8 +289,8 @@ static int m2o_system(mav2odid_t *m2o, mavlink_open_drone_id_system_t *mavSystem
         (ODID_operator_location_type_t) mavSystem->operator_location_type;
     system.ClassificationType =
         (ODID_classification_type_t) mavSystem->classification_type;
-    system.OperatorLatitude = (float) mavSystem->operator_latitude / 1E7;
-    system.OperatorLongitude = (float) mavSystem->operator_longitude / 1E7;
+    system.OperatorLatitude = (double) mavSystem->operator_latitude / 1E7;
+    system.OperatorLongitude = (double) mavSystem->operator_longitude / 1E7;
     system.AreaCount = mavSystem->area_count;
     system.AreaRadius = mavSystem->area_radius;
     system.AreaCeiling = mavSystem->area_ceiling;

--- a/libmav2odid/mav2odid.c
+++ b/libmav2odid/mav2odid.c
@@ -285,13 +285,18 @@ static int m2o_selfId(mav2odid_t *m2o, mavlink_open_drone_id_self_id_t *mavSelfI
 static int m2o_system(mav2odid_t *m2o, mavlink_open_drone_id_system_t *mavSystem)
 {
     ODID_System_data system;
-    system.LocationSource = (ODID_location_source_t) mavSystem->flags;
+    system.OperatorLocationType =
+        (ODID_operator_location_type_t) mavSystem->operator_location_type;
+    system.ClassificationType =
+        (ODID_classification_type_t) mavSystem->classification_type;
     system.OperatorLatitude = (float) mavSystem->operator_latitude / 1E7;
     system.OperatorLongitude = (float) mavSystem->operator_longitude / 1E7;
     system.AreaCount = mavSystem->area_count;
     system.AreaRadius = mavSystem->area_radius;
     system.AreaCeiling = mavSystem->area_ceiling;
     system.AreaFloor = mavSystem->area_floor;
+    system.CategoryEU = (ODID_category_EU_t) mavSystem->category_eu;
+    system.ClassEU = (ODID_class_EU_t) mavSystem->class_eu;
 
     return encodeSystemMessage(&m2o->systemEnc, &system);
 }
@@ -498,13 +503,18 @@ void m2o_selfId2Mavlink(mavlink_open_drone_id_self_id_t *mavSelfID,
 void m2o_system2Mavlink(mavlink_open_drone_id_system_t *mavSystem,
                         ODID_System_data *system)
 {
-    mavSystem->flags = (MAV_ODID_LOCATION_SRC) system->LocationSource;
+    mavSystem->operator_location_type =
+        (MAV_ODID_OPERATOR_LOCATION_TYPE) system->OperatorLocationType;
+    mavSystem->classification_type =
+        (MAV_ODID_CLASSIFICATION_TYPE) system->ClassificationType;
     mavSystem->operator_latitude = (int32_t) (system->OperatorLatitude * 1E7);
     mavSystem->operator_longitude = (int32_t) (system->OperatorLongitude * 1E7);
     mavSystem->area_count = system->AreaCount;
     mavSystem->area_radius = system->AreaRadius;
     mavSystem->area_ceiling = system->AreaCeiling;
     mavSystem->area_floor = system->AreaFloor;
+    mavSystem->category_eu = (ODID_category_EU_t) system->CategoryEU;
+    mavSystem->class_eu = (ODID_class_EU_t) system->ClassEU;
 }
 
 /**

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -398,7 +398,11 @@ int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inDat
 */
 int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData)
 {
-    if (!outEncoded || !inData || !intInRange(inData->LocationSource, 0, 3))
+    if (!outEncoded || !inData ||
+        !intInRange(inData->OperatorLocationType, 0, 3) ||
+        !intInRange(inData->ClassificationType, 0, 7) ||
+        !intInRange(inData->CategoryEU, 0, 15) ||
+        !intInRange(inData->ClassEU, 0, 15))
         return ODID_FAIL;
 
     if (inData->OperatorLatitude < MIN_LAT || inData->OperatorLatitude > MAX_LAT ||
@@ -415,13 +419,16 @@ int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inDat
     outEncoded->MessageType = ODID_MESSAGETYPE_SYSTEM;
     outEncoded->ProtoVersion = ODID_PROTOCOL_VERSION;
     outEncoded->Reserved = 0;
-    outEncoded->LocationSource = inData->LocationSource;
+    outEncoded->OperatorLocationType = inData->OperatorLocationType;
+    outEncoded->ClassificationType = inData->ClassificationType;
     outEncoded->OperatorLatitude = encodeLatLon(inData->OperatorLatitude);
     outEncoded->OperatorLongitude = encodeLatLon(inData->OperatorLongitude);
     outEncoded->AreaCount = inData->AreaCount;
     outEncoded->AreaRadius = encodeAreaRadius(inData->AreaRadius);
     outEncoded->AreaCeiling = encodeAltitude(inData->AreaCeiling);
     outEncoded->AreaFloor = encodeAltitude(inData->AreaFloor);
+    outEncoded->CategoryEU = inData->CategoryEU;
+    outEncoded->ClassEU = inData->ClassEU;
     memset(outEncoded->Reserved2, 0, sizeof(outEncoded->Reserved2));
     return ODID_SUCCESS;
 }
@@ -732,13 +739,18 @@ int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncode
         inEncoded->MessageType != ODID_MESSAGETYPE_SYSTEM)
         return ODID_FAIL;
 
-    outData->LocationSource = (ODID_location_source_t) inEncoded->LocationSource;
+    outData->OperatorLocationType =
+        (ODID_operator_location_type_t) inEncoded->OperatorLocationType;
+    outData->ClassificationType =
+        (ODID_classification_type_t) inEncoded->ClassificationType;
     outData->OperatorLatitude = decodeLatLon(inEncoded->OperatorLatitude);
     outData->OperatorLongitude = decodeLatLon(inEncoded->OperatorLongitude);
     outData->AreaCount = inEncoded->AreaCount;
     outData->AreaRadius = decodeAreaRadius(inEncoded->AreaRadius);
     outData->AreaCeiling = decodeAltitude(inEncoded->AreaCeiling);
     outData->AreaFloor = decodeAltitude(inEncoded->AreaFloor);
+    outData->CategoryEU = (ODID_category_EU_t) inEncoded->CategoryEU;
+    outData->ClassEU = (ODID_class_EU_t) inEncoded->ClassEU;
     return ODID_SUCCESS;
 }
 
@@ -1337,12 +1349,16 @@ void printSelfID_data(ODID_SelfID_data *SelfID)
 */
 void printSystem_data(ODID_System_data *System_data)
 {
-    const char ODID_System_data_format[] = "Location Source: %d\nLat/Lon: "\
-        "%.7f, %.7f\nArea Count, Radius, Ceiling, Floor: %d, %d, %.2f, %.2f\n";
-    printf(ODID_System_data_format, System_data->LocationSource,
+    const char ODID_System_data_format[] = "Operator Location Type: %d\n"
+        "Classification Type: %d\nLat/Lon: %.7f, %.7f\n"
+        "Area Count, Radius, Ceiling, Floor: %d, %d, %.2f, %.2f\n"
+        "Category EU: %d, Class EU: %d\n";
+    printf(ODID_System_data_format, System_data->OperatorLocationType,
+        System_data->ClassificationType,
         System_data->OperatorLatitude, System_data->OperatorLongitude,
         System_data->AreaCount, System_data->AreaRadius,
-        System_data->AreaCeiling, System_data->AreaFloor);
+        System_data->AreaCeiling, System_data->AreaFloor,
+        System_data->CategoryEU, System_data->ClassEU);
 }
 
 /**

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -18,9 +18,9 @@ gabriel.c.cox@intel.com
 #define ENABLE_DEBUG 1
 
 const float SPEED_DIV[2] = {0.25f, 0.75f};
-const float VSPEED_DIV = 0.5;
+const float VSPEED_DIV = 0.5f;
 const int32_t LATLON_MULT = 10000000;
-const float ALT_DIV = 0.5;
+const float ALT_DIV = 0.5f;
 const int ALT_ADDER = 1000;
 const int DATA_AGE_DIV = 10;
 

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -1290,16 +1290,18 @@ void printLocation_data(ODID_Location_data *Location)
         "%.2f\nLat/Lon: %.7f, %.7f\nAlt: Baro, Geo, Height above %s: %.2f, "\
         "%.2f, %.2f\nHoriz, Vert, Baro, Speed, TS Accuracy: %.1f, %.1f, %.1f, "\
         "%.1f, %.1f\nTimeStamp: %.2f\n";
-    printf(ODID_Location_data_format, Location->Status, Location->Direction,
-        Location->SpeedHorizontal, Location->SpeedVertical, Location->Latitude,
+    printf(ODID_Location_data_format, Location->Status,
+        (double) Location->Direction, (double) Location->SpeedHorizontal,
+        (double) Location->SpeedVertical, Location->Latitude,
         Location->Longitude, Location->HeightType ? "Ground" : "TakeOff",
-        Location->AltitudeBaro, Location->AltitudeGeo, Location->Height,
-        decodeHorizontalAccuracy(Location->HorizAccuracy),
-        decodeVerticalAccuracy(Location->VertAccuracy),
-        decodeVerticalAccuracy(Location->BaroAccuracy),
-        decodeSpeedAccuracy(Location->SpeedAccuracy),
-        decodeTimestampAccuracy(Location->TSAccuracy),
-        Location->TimeStamp);
+        (double) Location->AltitudeBaro, (double) Location->AltitudeGeo,
+        (double) Location->Height,
+        (double) decodeHorizontalAccuracy(Location->HorizAccuracy),
+        (double) decodeVerticalAccuracy(Location->VertAccuracy),
+        (double) decodeVerticalAccuracy(Location->BaroAccuracy),
+        (double) decodeSpeedAccuracy(Location->SpeedAccuracy),
+        (double) decodeTimestampAccuracy(Location->TSAccuracy),
+        (double) Location->TimeStamp);
 }
 
 /**
@@ -1357,7 +1359,7 @@ void printSystem_data(ODID_System_data *System_data)
         System_data->ClassificationType,
         System_data->OperatorLatitude, System_data->OperatorLongitude,
         System_data->AreaCount, System_data->AreaRadius,
-        System_data->AreaCeiling, System_data->AreaFloor,
+        (double) System_data->AreaCeiling, (double) System_data->AreaFloor,
         System_data->CategoryEU, System_data->ClassEU);
 }
 

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -33,7 +33,7 @@ gabriel.c.cox@intel.com
 #define MIN_SPEED_H     0       // Minimum speed horizontal
 #define MAX_SPEED_H     254.25  // Maximum speed horizontal
 #define INV_SPEED_H     255     // Invalid speed horizontal
-#define MIN_SPEED_V     -62       // Minimum speed vertical
+#define MIN_SPEED_V     -62     // Minimum speed vertical
 #define MAX_SPEED_V     62      // Maximum speed vertical
 #define INV_SPEED_V     63      // Invalid speed vertical
 #define MIN_LAT         -90     // Minimum latitude
@@ -90,6 +90,7 @@ typedef enum ODID_status {
     ODID_STATUS_UNDECLARED = 0,
     ODID_STATUS_GROUND = 1,
     ODID_STATUS_AIRBORNE = 2,
+    ODID_STATUS_EMERGENCY = 3,
     // 3 to 15 reserved
 } ODID_status_t;
 
@@ -175,12 +176,38 @@ typedef enum ODID_operatorIdType {
     // 201 to 255 available for private use
 } ODID_operatorIdType_t;
 
-typedef enum ODID_location_source {
-    ODID_LOCATION_SRC_TAKEOFF = 0,
-    ODID_LOCATION_SRC_LIVE_GNSS = 1,
-    ODID_LOCATION_SRC_FIXED = 2,
+typedef enum ODID_operator_location_type {
+    ODID_OPERATOR_LOCATION_TYPE_TAKEOFF = 0,
+    ODID_OPERATOR_LOCATION_TYPE_LIVE_GNSS = 1,
+    ODID_OPERATOR_LOCATION_TYPE_FIXED = 2,
     // 3 to 255 reserved
-} ODID_location_source_t;
+} ODID_operator_location_type_t;
+
+typedef enum ODID_classification_type {
+    ODID_CLASSIFICATION_TYPE_UNDECLARED = 0,
+    ODID_CLASSIFICATION_TYPE_EU = 1, // European Union
+    // 2 to 7 reserved
+} ODID_classification_type_t;
+
+typedef enum ODID_category_EU {
+    ODID_CATEGORY_EU_UNDECLARED = 0,
+    ODID_CATEGORY_EU_OPEN = 1,
+    ODID_CATEGORY_EU_SPECIFIC = 2,
+    ODID_CATEGORY_EU_CERTIFIED = 3,
+    // 4 to 15 reserved
+} ODID_category_EU_t;
+
+typedef enum ODID_class_EU {
+    ODID_CLASS_EU_UNDECLARED = 0,
+    ODID_CLASS_EU_CLASS_0 = 1,
+    ODID_CLASS_EU_CLASS_1 = 2,
+    ODID_CLASS_EU_CLASS_2 = 3,
+    ODID_CLASS_EU_CLASS_3 = 4,
+    ODID_CLASS_EU_CLASS_4 = 5,
+    ODID_CLASS_EU_CLASS_5 = 6,
+    ODID_CLASS_EU_CLASS_6 = 7,
+    // 8 to 15 reserved
+} ODID_class_EU_t;
 
  /*
  * @name ODID_DataStructs
@@ -236,13 +263,16 @@ typedef struct {
 } ODID_SelfID_data;
 
 typedef struct {
-    ODID_location_source_t LocationSource;
+    ODID_operator_location_type_t OperatorLocationType;
+    ODID_classification_type_t ClassificationType;
     double OperatorLatitude;  // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
     double OperatorLongitude; // Invalid, No Value, or Unknown: 0 deg (both Lat/Lon)
     uint16_t AreaCount;       // Default 1
     uint16_t AreaRadius;      // meter. Default 0
     float AreaCeiling;        // meter. Invalid, No Value, or Unknown: -1000m
     float AreaFloor;          // meter. Invalid, No Value, or Unknown: -1000m
+    ODID_category_EU_t CategoryEU; // Only filled if ClassificationType = ODID_CLASSIFICATION_TYPE_EU
+    ODID_class_EU_t ClassEU;       // Only filled if ClassificationType = ODID_CLASSIFICATION_TYPE_EU
 } ODID_System_data;
 
 typedef struct {
@@ -382,9 +412,10 @@ typedef struct __attribute__((__packed__)) {
     uint8_t ProtoVersion: 4;
     uint8_t MessageType : 4;
 
-    // Byte 1 [Reserved][LocationSource]
-    uint8_t Reserved: 7;
-    uint8_t LocationSource: 1;
+    // Byte 1 [Reserved][ClassificationType][OperatorLocationType]  -- must define LSb first
+    uint8_t OperatorLocationType: 2;
+    uint8_t ClassificationType: 3;
+    uint8_t Reserved: 3;
 
     // Byte 2-9
     int32_t OperatorLatitude;
@@ -396,8 +427,12 @@ typedef struct __attribute__((__packed__)) {
     uint16_t AreaCeiling;
     uint16_t AreaFloor;
 
-    // Byte 17-24
-    char Reserved2[8];
+    // Byte 17 [CategoryEU][ClassEU]  -- must define LSb first
+    uint8_t ClassEU: 4;
+    uint8_t CategoryEU: 4;
+
+    // Byte 18-24
+    char Reserved2[7];
 } ODID_System_encoded;
 
 typedef struct __attribute__((__packed__)) {

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -31,7 +31,7 @@ gabriel.c.cox@intel.com
 #define MAX_DIR         360     // Maximum direction
 #define INV_DIR         361     // Invalid direction
 #define MIN_SPEED_H     0       // Minimum speed horizontal
-#define MAX_SPEED_H     254.25  // Maximum speed horizontal
+#define MAX_SPEED_H     254.25f // Maximum speed horizontal
 #define INV_SPEED_H     255     // Invalid speed horizontal
 #define MIN_SPEED_V     -62     // Minimum speed vertical
 #define MAX_SPEED_V     62      // Maximum speed vertical
@@ -41,7 +41,7 @@ gabriel.c.cox@intel.com
 #define MIN_LON         -180    // Minimum longitude
 #define MAX_LON         180     // Maximum longitude
 #define MIN_ALT         -1000   // Minimum altitude
-#define MAX_ALT         31767.5 // Maximum altitude
+#define MAX_ALT         31767.5f// Maximum altitude
 #define INV_ALT         MIN_ALT // Invalid altitude
 #define MAX_TIMESTAMP   (60 * 60 * 10)
 #define MAX_AUTH_LENGTH ((ODID_STR_SIZE - ODID_AUTH_PAGE_ZERO_DATA_SIZE) + \

--- a/libopendroneid/wifi.c
+++ b/libopendroneid/wifi.c
@@ -86,13 +86,16 @@ void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
 	mprintf("\t\t},\n");
 
 	mprintf("\t\t\"Operator\": {\n");
-	mprintf("\t\t\t\"LocationSource\": %d,\n", UAS_Data->System.LocationSource);
+	mprintf("\t\t\t\"OperatorLocationType\": %d,\n", UAS_Data->System.OperatorLocationType);
+	mprintf("\t\t\t\"ClassificationType\": %d,\n", UAS_Data->System.ClassificationType);
 	mprintf("\t\t\t\"OperatorLatitude\": %f,\n", UAS_Data->System.OperatorLatitude);
 	mprintf("\t\t\t\"OperatorLongitude\": %f,\n", UAS_Data->System.OperatorLongitude);
 	mprintf("\t\t\t\"AreaCount\": %d,\n", UAS_Data->System.AreaCount);
 	mprintf("\t\t\t\"AreaRadius\": %d,\n", UAS_Data->System.AreaRadius);
 	mprintf("\t\t\t\"AreaCeiling\": %f\n", UAS_Data->System.AreaCeiling);
 	mprintf("\t\t\t\"AreaFloor\": %f\n", UAS_Data->System.AreaFloor);
+	mprintf("\t\t\t\"CategoryEU\": %d,\n", UAS_Data->System.CategoryEU);
+	mprintf("\t\t\t\"ClassEU\": %d,\n", UAS_Data->System.ClassEU);
 	mprintf("\t\t}\n");
 
 	mprintf("\t\t\"OperatorID\": {\n");

--- a/libopendroneid/wifi.c
+++ b/libopendroneid/wifi.c
@@ -53,21 +53,21 @@ void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
 
 	mprintf("\t\t\"Location\": {\n");
 	mprintf("\t\t\t\"Status\": %d,\n", (int)UAS_Data->Location.Status);
-	mprintf("\t\t\t\"Direction\": %f,\n", UAS_Data->Location.Direction);
-	mprintf("\t\t\t\"SpeedHorizontal\": %f,\n", UAS_Data->Location.SpeedHorizontal);
-	mprintf("\t\t\t\"SpeedVertical\": %f,\n", UAS_Data->Location.SpeedVertical);
+	mprintf("\t\t\t\"Direction\": %f,\n", (double) UAS_Data->Location.Direction);
+	mprintf("\t\t\t\"SpeedHorizontal\": %f,\n", (double) UAS_Data->Location.SpeedHorizontal);
+	mprintf("\t\t\t\"SpeedVertical\": %f,\n", (double) UAS_Data->Location.SpeedVertical);
 	mprintf("\t\t\t\"Latitude\": %f,\n", UAS_Data->Location.Latitude);
 	mprintf("\t\t\t\"Longitude\": %f,\n", UAS_Data->Location.Longitude);
-	mprintf("\t\t\t\"AltitudeBaro\": %f,\n", UAS_Data->Location.AltitudeBaro);
-	mprintf("\t\t\t\"AltitudeGeo\": %f,\n", UAS_Data->Location.AltitudeGeo);
+	mprintf("\t\t\t\"AltitudeBaro\": %f,\n", (double) UAS_Data->Location.AltitudeBaro);
+	mprintf("\t\t\t\"AltitudeGeo\": %f,\n", (double) UAS_Data->Location.AltitudeGeo);
 	mprintf("\t\t\t\"HeightType\": %d,\n", UAS_Data->Location.HeightType);
-	mprintf("\t\t\t\"Height\": %f,\n", UAS_Data->Location.Height);
+	mprintf("\t\t\t\"Height\": %f,\n", (double) UAS_Data->Location.Height);
 	mprintf("\t\t\t\"HorizAccuracy\": %d,\n", UAS_Data->Location.HorizAccuracy);
 	mprintf("\t\t\t\"VertAccuracy\": %d,\n", UAS_Data->Location.VertAccuracy);
 	mprintf("\t\t\t\"BaroAccuracy\": %d,\n", UAS_Data->Location.BaroAccuracy);
 	mprintf("\t\t\t\"SpeedAccuracy\": %d,\n", UAS_Data->Location.SpeedAccuracy);
 	mprintf("\t\t\t\"TSAccuracy\": %d,\n", UAS_Data->Location.TSAccuracy);
-	mprintf("\t\t\t\"TimeStamp\": %f\n", UAS_Data->Location.TimeStamp);
+	mprintf("\t\t\t\"TimeStamp\": %f\n", (double) UAS_Data->Location.TimeStamp);
 	mprintf("\t\t},\n");
 
 	mprintf("\t\t\"Authentication\": {\n");
@@ -92,8 +92,8 @@ void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
 	mprintf("\t\t\t\"OperatorLongitude\": %f,\n", UAS_Data->System.OperatorLongitude);
 	mprintf("\t\t\t\"AreaCount\": %d,\n", UAS_Data->System.AreaCount);
 	mprintf("\t\t\t\"AreaRadius\": %d,\n", UAS_Data->System.AreaRadius);
-	mprintf("\t\t\t\"AreaCeiling\": %f\n", UAS_Data->System.AreaCeiling);
-	mprintf("\t\t\t\"AreaFloor\": %f\n", UAS_Data->System.AreaFloor);
+	mprintf("\t\t\t\"AreaCeiling\": %f\n", (double) UAS_Data->System.AreaCeiling);
+	mprintf("\t\t\t\"AreaFloor\": %f\n", (double) UAS_Data->System.AreaFloor);
 	mprintf("\t\t\t\"CategoryEU\": %d,\n", UAS_Data->System.CategoryEU);
 	mprintf("\t\t\t\"ClassEU\": %d,\n", UAS_Data->System.ClassEU);
 	mprintf("\t\t}\n");

--- a/test/opendroneid_sim.c
+++ b/test/opendroneid_sim.c
@@ -32,8 +32,8 @@ ODID_System_data system_data;
 ODID_OperatorID_data operatorID_data;
 
 const int SIM_STEPS = 20;
-const float SIM_STEP_SIZE = 0.0001;
-const float DISTANCE_PER_LAT = 111699.0;
+const double SIM_STEP_SIZE = 0.0001;
+const double DISTANCE_PER_LAT = 111699.0;
 
 
 double simLat = 45.5393092;

--- a/test/opendroneid_sim.c
+++ b/test/opendroneid_sim.c
@@ -146,13 +146,16 @@ void ODID_getSimData(uint8_t *message, uint8_t msgType)
             break;
 
         case 4:
-            system_data.LocationSource = ODID_LOCATION_SRC_TAKEOFF;
+            system_data.OperatorLocationType = ODID_OPERATOR_LOCATION_TYPE_TAKEOFF;
+            system_data.ClassificationType = ODID_CLASSIFICATION_TYPE_EU;
             system_data.OperatorLatitude = simGndLat;
             system_data.OperatorLongitude = simGndLon;
             system_data.AreaCount = 35;
             system_data.AreaRadius = 75;
             system_data.AreaCeiling = 176.9;
             system_data.AreaFloor = 41.7;
+            system_data.CategoryEU = ODID_CATEGORY_EU_SPECIFIC;
+            system_data.ClassEU = ODID_CLASS_EU_CLASS_3;
             encodeSystemMessage(&system_enc, &system_data);
             memcpy(message, &system_enc, ODID_MESSAGE_SIZE);
             break;

--- a/test/test_inout.c
+++ b/test/test_inout.c
@@ -102,13 +102,16 @@ void test_InOut()
     printSelfID_data(&SelfID);
     encodeSelfIDMessage(&SelfID_enc, &SelfID);
 
-    System_data.LocationSource = ODID_LOCATION_SRC_TAKEOFF;
+    System_data.OperatorLocationType = ODID_OPERATOR_LOCATION_TYPE_TAKEOFF;
+    System_data.ClassificationType = ODID_CLASSIFICATION_TYPE_EU;
     System_data.OperatorLatitude = Location.Latitude + 0.00001;
     System_data.OperatorLongitude = Location.Longitude + 0.00001;
     System_data.AreaCount = 35;
     System_data.AreaRadius = 75;
     System_data.AreaCeiling = 176.9;
     System_data.AreaFloor = 41.7;
+    System_data.CategoryEU = ODID_CATEGORY_EU_SPECIFIC;
+    System_data.ClassEU = ODID_CLASS_EU_CLASS_3;
     printf("\nSystem\n------\n");
     printSystem_data(&System_data);
     encodeSystemMessage(&System_enc, &System_data);

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -37,11 +37,11 @@ static void print_mavlink_location(mavlink_open_drone_id_location_t *location)
            location->status, location->direction, location->speed_horizontal,
            location->speed_vertical, location->latitude, location->longitude,
            location->height_reference ? "Ground" : "TakeOff",
-           location->altitude_barometric, location->altitude_geodetic,
-           location->height,
+           (double) location->altitude_barometric,
+           (double) location->altitude_geodetic, (double) location->height,
            location->horizontal_accuracy, location->vertical_accuracy,
            location->barometer_accuracy, location->speed_accuracy,
-           location->timestamp_accuracy, location->timestamp);
+           location->timestamp_accuracy, (double) location->timestamp);
 }
 
 static void print_mavlink_auth(mavlink_open_drone_id_authentication_t *auth)
@@ -80,7 +80,7 @@ static void print_mavlink_system(mavlink_open_drone_id_system_t *system)
            system->operator_location_type, system->classification_type,
            system->operator_latitude, system->operator_longitude,
            system->area_count, system->area_radius,
-           system->area_ceiling, system->area_floor,
+           (double) system->area_ceiling, (double) system->area_floor,
            system->category_eu, system->class_eu);
 }
 
@@ -181,7 +181,7 @@ static void test_location(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
         .direction = (uint16_t) (27.4f * 100),
         .speed_horizontal = (uint16_t) (4.25f * 100),
         .speed_vertical = (uint16_t) (4.5f * 100),
-        .latitude = (int32_t) (51.477f * 1E7),
+        .latitude = (int32_t) (51.477 * 1E7),
         .longitude = (int32_t) (0.0005 * 1E7),
         .altitude_barometric = 37.5f,
         .altitude_geodetic = 36.5f,
@@ -288,8 +288,8 @@ static void test_system(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
     mavlink_open_drone_id_system_t system = {
         .operator_location_type = MAV_ODID_OPERATOR_LOCATION_TYPE_TAKEOFF,
         .classification_type = MAV_ODID_CLASSIFICATION_TYPE_EU,
-        .operator_latitude = (int32_t) (51.477f * 1E7),
-        .operator_longitude = (int32_t) (0.0005f * 1E7),
+        .operator_latitude = (int32_t) (51.477 * 1E7),
+        .operator_longitude = (int32_t) (0.0005 * 1E7),
         .area_count = 350,
         .area_radius = 55,
         .area_ceiling = 75.5f,

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -103,7 +103,7 @@ static void send_parse_tx_rx(mav2odid_t *m2o, mavlink_message_t *msg,
                              ODID_messagetype_t *msgType)
 {
     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
-    uint16_t length = mavlink_msg_to_send_buffer(buf, msg);
+    mavlink_msg_to_send_buffer(buf, msg);
 
     ODID_messagetype_t msg_type = ODID_MESSAGETYPE_INVALID;
     int i = 0;

--- a/test/test_mav2odid.c
+++ b/test/test_mav2odid.c
@@ -73,11 +73,15 @@ static void print_mavlink_selfID(mavlink_open_drone_id_self_id_t *self_id)
 
 static void print_mavlink_system(mavlink_open_drone_id_system_t *system)
 {
-    printf("Location Source: %d\nLat/Lon: %d, %d degE7, Area Count, Radius: %d, %d, \n"\
-           "Ceiling, Floor: %.2f, %.2f m\n",
-           system->flags, system->operator_latitude,
-           system->operator_longitude, system->area_count,
-           system->area_radius, system->area_ceiling, system->area_floor);
+    printf("Operator Location Type: %d, Classification Type: %d\n"
+           "Lat/Lon: %d, %d degE7, \n"
+           "Area Count, Radius: %d, %d, Ceiling, Floor: %.2f, %.2f m\n"
+           "Category EU: %d, Class EU: %d\n",
+           system->operator_location_type, system->classification_type,
+           system->operator_latitude, system->operator_longitude,
+           system->area_count, system->area_radius,
+           system->area_ceiling, system->area_floor,
+           system->category_eu, system->class_eu);
 }
 
 static void print_mavlink_operatorID(mavlink_open_drone_id_operator_id_t *operator_id)
@@ -142,7 +146,7 @@ static void test_basicId(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
 {
     mavlink_message_t msg = { 0 };
     mavlink_open_drone_id_basic_id_t basic_id = {
-        .ua_type = MAV_ODID_UA_TYPE_ROTORCRAFT,
+        .ua_type = MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR,
         .id_type = MAV_ODID_ID_TYPE_SERIAL_NUMBER,
         .uas_id = "9876543210ABCDEFGHJK" };
 
@@ -282,13 +286,16 @@ static void test_system(mav2odid_t *m2o, ODID_UAS_Data *uas_data)
 {
     mavlink_message_t msg = { 0 };
     mavlink_open_drone_id_system_t system = {
-        .flags = MAV_ODID_LOCATION_SRC_TAKEOFF,
+        .operator_location_type = MAV_ODID_OPERATOR_LOCATION_TYPE_TAKEOFF,
+        .classification_type = MAV_ODID_CLASSIFICATION_TYPE_EU,
         .operator_latitude = (int32_t) (51.477f * 1E7),
         .operator_longitude = (int32_t) (0.0005f * 1E7),
         .area_count = 350,
         .area_radius = 55,
         .area_ceiling = 75.5f,
-        .area_floor = 26.5f };
+        .area_floor = 26.5f,
+        .category_eu = MAV_ODID_CATEGORY_EU_CERTIFIED,
+        .class_eu = MAV_ODID_CLASS_EU_CLASS_5 };
 
     printf("\n\n------------------------System------------------------\n\n");
     print_mavlink_system(&system);

--- a/wifi/sender/main.c
+++ b/wifi/sender/main.c
@@ -283,13 +283,16 @@ static void drone_set_mock_data(ODID_UAS_Data *drone)
 	strncpy(drone->SelfID.Desc, description, sizeof(description));
 
 	/* System data */
-	drone->System.LocationSource = ODID_LOCATION_SRC_TAKEOFF;
+	drone->System.OperatorLocationType = ODID_OPERATOR_LOCATION_TYPE_TAKEOFF;
+	drone->System.ClassificationType = ODID_CLASSIFICATION_TYPE_UNDECLARED;
 	drone->System.OperatorLatitude = drone->Location.Latitude + 0.00001;
 	drone->System.OperatorLongitude = drone->Location.Longitude + 0.00001;
 	drone->System.AreaCount = 20;
 	drone->System.AreaRadius = 50;
 	drone->System.AreaCeiling = 150.0;
 	drone->System.AreaFloor = 25.0;
+	drone->System.CategoryEU = ODID_CATEGORY_EU_UNDECLARED;
+	drone->System.ClassEU = ODID_CLASS_EU_UNDECLARED;
 
 	/* Operator ID */
 	drone->OperatorID.OperatorIdType = ODID_OPERATOR_ID;

--- a/wifi/sender/main.c
+++ b/wifi/sender/main.c
@@ -234,8 +234,10 @@ static void drone_adopt_gps_data(ODID_UAS_Data *drone,
 	       "TimeStamp: %f, time since last hour (100ms): %ld, TSAccuracy: %d\n\t"
 	       "Direction: %f, SpeedHorizontal: %f, SpeedVertical: %f\n\t"
 	       "Latitude: %f, Longitude: %f\n",
-	       drone->Location.TimeStamp, (uint64_t)(drone->Location.TimeStamp*10)%36000, drone->Location.TSAccuracy,
-	       drone->Location.Direction, drone->Location.SpeedHorizontal, drone->Location.SpeedVertical,
+	       (double) drone->Location.TimeStamp,
+		   (uint64_t)(drone->Location.TimeStamp*10)%36000, drone->Location.TSAccuracy,
+	       (double) drone->Location.Direction, (double) drone->Location.SpeedHorizontal,
+		   (double) drone->Location.SpeedVertical,
 	       drone->Location.Latitude, drone->Location.Longitude
 	);
 }


### PR DESCRIPTION
The ASD-STAN Direct Remote ID standard introduces new fields
for transmitting classification data.

Changed the name of the operator location type to be more
descriptive and at the same time fixed a bug where this
field was encoded with too few bits and in the wrong position.

Also a new status enum value for Emergency has been defined.

A future version of the ASTM Remote ID standard will include
the same new fields and values.

The mav2odid code was reducing the precision of latitudes
and longitudes when doing the conversions.

Avoid unnecessary conversion from float to double when
checking input values against max/min values.