### PR TITLE
Add NAN Service Descriptor extension attribute to NAN action frame

### DIFF
--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -613,6 +613,13 @@ struct __attribute__((__packed__)) nan_service_descriptor_attribute {
 	uint8_t service_info_length;
 };
 
+struct __attribute__((__packed__)) nan_service_descriptor_extension_attribute {
+	struct nan_attribute_header header;
+	uint8_t instance_id;
+	uint16_t control;
+	uint8_t service_update_indicator;
+};
+
 struct __attribute__((__packed__)) ODID_service_info {
 	uint8_t message_counter;
 	ODID_MessagePack_encoded odid_message_pack[];

--- a/libopendroneid/wifi.c
+++ b/libopendroneid/wifi.c
@@ -153,6 +153,7 @@ int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char 
 	struct ieee80211_mgmt *mgmt;
 	struct nan_service_discovery *nsd;
 	struct nan_service_descriptor_attribute *nsda;
+	struct nan_service_descriptor_extension_attribute *nsdea;
 	struct ODID_service_info *si;
 	long ret, len = 0;
 
@@ -213,6 +214,18 @@ int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char 
 	/* set the lengths according to the message pack lengths */
 	nsda->service_info_length = sizeof(*si) + ret;
 	nsda->length = cpu_to_le16(sizeof(*nsda) - sizeof(struct nan_attribute_header) + nsda->service_info_length);
+
+	/* NAN Attribute for Service Descriptor extension header */
+	if (len + sizeof(*nsdea) > buf_size)
+		return -ENOMEM;
+
+	nsdea = (struct nan_service_descriptor_extension_attribute *)(buf + len);
+	nsdea->header.attribute_id = 0xE;
+	nsdea->header.length = cpu_to_le16(0x0004);
+	nsdea->instance_id = 0x01;
+	nsdea->control = cpu_to_le16(0x0200);
+	nsdea->service_update_indicator = send_counter;
+	len += sizeof(*nsdea);
 
 	return len;
 }


### PR DESCRIPTION
This attribute is not mandatory in our case, as specified in the Neighbor Awareness Networking Specification v3.1, but it is very convenient to have the Service Update Indicator for debugging with Wireshark.