### PR TITLE
fix build errors with libgps 3.20 and newer

### DIFF
--- a/wifi/sender/CMakeLists.txt
+++ b/wifi/sender/CMakeLists.txt
@@ -10,6 +10,9 @@ link_libraries(opendroneid m ${GPS_LIBRARIES} ${NL_LIBRARIES} ${GENL_LIBRARIES})
 include_directories(../../libopendroneid ${GPS_INCLUDE_DIRS} ${NL_INCLUDE_DIRS} ${GENL_INCLUDE_DIRS})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GPS_CFLAGS_OTHER} ${NL_CFLAGS_OTHER} ${GENL_CFLAGS_OTHER}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wno-unused-parameter -std=gnu99 -fno-strict-aliasing -MD -MP -D_GNU_SOURCE")
+if (GPS_VERSION VERSION_LESS 3.20)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DLIBGPS_OLD")
+endif()
 
 add_executable(sender main.c)
 


### PR DESCRIPTION
* fixes #38
* happens e.g. on Ubuntu 20.04
* support for older libgps versions is maintained
* depending on the libgps version, we define a preprocessor flag
  and use conditional compilation to distinguish both cases
* the TSTONS macro is taken from:
  https://gitlab.com/gpsd/gpsd/-/blob/1d4a09541a18c453c5586e6f57d3eb5fec9526ed/timespec.h#L102