### PR TITLE
Fix rounding/encoding error for track direction

### DIFF
--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -165,6 +165,8 @@ void odid_initUasData(ODID_UAS_Data *data)
 static uint8_t encodeDirection(float Direction, uint8_t *EWDirection)
 {
     unsigned int direction_int = (unsigned int) roundf(Direction);
+    if (direction_int == 360)
+        direction_int = 0;
     if (direction_int < 180) {
         *EWDirection = 0;
     } else {


### PR DESCRIPTION
Values >=359.5 and <360 would be encoded wrongly as 180.

Fixes #79