### PR TITLE
const-correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,21 +217,21 @@ Once you have the encoded data, then you are ready to assemble and transmit over
 The primary SDK calls are the following:
 
 ```
-int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData);
-int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData);
-int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData);
-int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inData);
-int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData);
-int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID_data *inData);
-int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, ODID_MessagePack_data *inData);
+int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, const ODID_BasicID_data *inData);
+int encodeLocationMessage(ODID_Location_encoded *outEncoded, const ODID_Location_data *inData);
+int encodeAuthMessage(ODID_Auth_encoded *outEncoded, const ODID_Auth_data *inData);
+int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, const ODID_SelfID_data *inData);
+int encodeSystemMessage(ODID_System_encoded *outEncoded, const ODID_System_data *inData);
+int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, const ODID_OperatorID_data *inData);
+int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, const ODID_MessagePack_data *inData);
 
-int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEncoded);
-int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *inEncoded);
-int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded);
-int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncoded);
-int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncoded);
-int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encoded *inEncoded);
-int decodeMessagePack(ODID_UAS_Data *uasData, ODID_MessagePack_encoded *pack);
+int decodeBasicIDMessage(ODID_BasicID_data *outData, const ODID_BasicID_encoded *inEncoded);
+int decodeLocationMessage(ODID_Location_data *outData, const ODID_Location_encoded *inEncoded);
+int decodeAuthMessage(ODID_Auth_data *outData, const ODID_Auth_encoded *inEncoded);
+int decodeSelfIDMessage(ODID_SelfID_data *outData, const ODID_SelfID_encoded *inEncoded);
+int decodeSystemMessage(ODID_System_data *outData, const ODID_System_encoded *inEncoded);
+int decodeOperatorIDMessage(ODID_OperatorID_data *outData, const ODID_OperatorID_encoded *inEncoded);
+int decodeMessagePack(ODID_UAS_Data *uasData, const ODID_MessagePack_encoded *pack);
 ```
 
 Specific messages have been added to the MAVLink message set to accommodate data for Open Drone ID implementations:

--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -277,7 +277,7 @@ static uint8_t encodeAreaRadius(uint16_t Radius)
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData)
+int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, const ODID_BasicID_data *inData)
 {
     if (!outEncoded || !inData ||
         !intInRange(inData->IDType, 0, 15) ||
@@ -310,7 +310,7 @@ int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *in
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData)
+int encodeLocationMessage(ODID_Location_encoded *outEncoded, const ODID_Location_data *inData)
 {
     uint8_t bitflag;
     if (!outEncoded || !inData ||
@@ -381,7 +381,7 @@ int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data 
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData)
+int encodeAuthMessage(ODID_Auth_encoded *outEncoded, const ODID_Auth_data *inData)
 {
     if (!outEncoded || !inData || !intInRange(inData->AuthType, 0, 15))
         return ODID_FAIL;
@@ -429,7 +429,7 @@ int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData)
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inData)
+int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, const ODID_SelfID_data *inData)
 {
     if (!outEncoded || !inData || !intInRange(inData->DescType, 0, 255))
         return ODID_FAIL;
@@ -448,7 +448,7 @@ int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inDat
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData)
+int encodeSystemMessage(ODID_System_encoded *outEncoded, const ODID_System_data *inData)
 {
     if (!outEncoded || !inData ||
         !intInRange(inData->OperatorLocationType, 0, 3) ||
@@ -495,7 +495,7 @@ int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inDat
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID_data *inData)
+int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, const ODID_OperatorID_data *inData)
 {
     if (!outEncoded || !inData || !intInRange(inData->OperatorIdType, 0, 255))
         return ODID_FAIL;
@@ -515,7 +515,7 @@ int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID
 * @param amount The amount of messages in the pack
 * @return       ODID_SUCCESS or ODID_FAIL;
 */
-static int checkPackContent(ODID_Message_encoded *msgs, int amount)
+static int checkPackContent(const ODID_Message_encoded *msgs, int amount)
 {
     if (amount <= 0 || amount > ODID_PACK_MAX_MESSAGES)
         return ODID_FAIL;
@@ -551,7 +551,7 @@ static int checkPackContent(ODID_Message_encoded *msgs, int amount)
 * @param inData     Input data (non encoded/packed) structure
 * @return           ODID_SUCCESS or ODID_FAIL;
 */
-int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, ODID_MessagePack_data *inData)
+int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, const ODID_MessagePack_data *inData)
 {
     if (!outEncoded || !inData || inData->SingleMessageSize != ODID_MESSAGE_SIZE)
         return ODID_FAIL;
@@ -684,7 +684,7 @@ int getBasicIDType(ODID_BasicID_encoded *inEncoded, enum ODID_idtype *idType)
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEncoded)
+int decodeBasicIDMessage(ODID_BasicID_data *outData, const ODID_BasicID_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->MessageType != ODID_MESSAGETYPE_BASIC_ID ||
@@ -714,7 +714,7 @@ int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEnc
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *inEncoded)
+int decodeLocationMessage(ODID_Location_data *outData, const ODID_Location_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->MessageType != ODID_MESSAGETYPE_LOCATION ||
@@ -766,7 +766,7 @@ int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum)
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded)
+int decodeAuthMessage(ODID_Auth_data *outData, const ODID_Auth_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->page_zero.MessageType != ODID_MESSAGETYPE_AUTH ||
@@ -814,7 +814,7 @@ int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded)
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncoded)
+int decodeSelfIDMessage(ODID_SelfID_data *outData, const ODID_SelfID_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->MessageType != ODID_MESSAGETYPE_SELF_ID)
@@ -832,7 +832,7 @@ int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncode
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncoded)
+int decodeSystemMessage(ODID_System_data *outData, const ODID_System_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->MessageType != ODID_MESSAGETYPE_SYSTEM)
@@ -862,7 +862,7 @@ int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncode
 * @param inEncoded Input message (encoded/packed) structure
 * @return          ODID_SUCCESS or ODID_FAIL;
 */
-int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encoded *inEncoded)
+int decodeOperatorIDMessage(ODID_OperatorID_data *outData, const ODID_OperatorID_encoded *inEncoded)
 {
     if (!outData || !inEncoded ||
         inEncoded->MessageType != ODID_MESSAGETYPE_OPERATOR_ID)
@@ -884,7 +884,7 @@ int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encod
 * @param pack    Pointer to an encoded packed message
 * @return        ODID_SUCCESS or ODID_FAIL;
 */
-int decodeMessagePack(ODID_UAS_Data *uasData, ODID_MessagePack_encoded *pack)
+int decodeMessagePack(ODID_UAS_Data *uasData, const ODID_MessagePack_encoded *pack)
 {
     if (!uasData || !pack || pack->MessageType != ODID_MESSAGETYPE_PACKED)
         return ODID_FAIL;
@@ -946,7 +946,7 @@ ODID_messagetype_t decodeMessageType(uint8_t byte)
 *                   message
 * @return           The message type: ODID_messagetype_t
 */
-ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uasData, uint8_t *msgData)
+ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uasData, const uint8_t *msgData)
 {
     if (!uasData || !msgData)
         return ODID_MESSAGETYPE_INVALID;
@@ -1362,7 +1362,7 @@ float decodeTimestampAccuracy(ODID_Timestamp_accuracy_t Accuracy)
 * @param asize Size of array of bytes to be printed
 */
 
-void printByteArray(uint8_t *byteArray, uint16_t asize, int spaced)
+void printByteArray(const uint8_t *byteArray, uint16_t asize, int spaced)
 {
     if (ENABLE_DEBUG) {
         int x;

--- a/libopendroneid/opendroneid.h
+++ b/libopendroneid/opendroneid.h
@@ -626,26 +626,26 @@ void odid_initOperatorIDData(ODID_OperatorID_data *data);
 void odid_initMessagePackData(ODID_MessagePack_data *data);
 void odid_initUasData(ODID_UAS_Data *data);
 
-int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, ODID_BasicID_data *inData);
-int encodeLocationMessage(ODID_Location_encoded *outEncoded, ODID_Location_data *inData);
-int encodeAuthMessage(ODID_Auth_encoded *outEncoded, ODID_Auth_data *inData);
-int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, ODID_SelfID_data *inData);
-int encodeSystemMessage(ODID_System_encoded *outEncoded, ODID_System_data *inData);
-int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, ODID_OperatorID_data *inData);
-int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, ODID_MessagePack_data *inData);
+int encodeBasicIDMessage(ODID_BasicID_encoded *outEncoded, const ODID_BasicID_data *inData);
+int encodeLocationMessage(ODID_Location_encoded *outEncoded, const ODID_Location_data *inData);
+int encodeAuthMessage(ODID_Auth_encoded *outEncoded, const ODID_Auth_data *inData);
+int encodeSelfIDMessage(ODID_SelfID_encoded *outEncoded, const ODID_SelfID_data *inData);
+int encodeSystemMessage(ODID_System_encoded *outEncoded, const ODID_System_data *inData);
+int encodeOperatorIDMessage(ODID_OperatorID_encoded *outEncoded, const ODID_OperatorID_data *inData);
+int encodeMessagePack(ODID_MessagePack_encoded *outEncoded, const ODID_MessagePack_data *inData);
 
-int decodeBasicIDMessage(ODID_BasicID_data *outData, ODID_BasicID_encoded *inEncoded);
-int decodeLocationMessage(ODID_Location_data *outData, ODID_Location_encoded *inEncoded);
-int decodeAuthMessage(ODID_Auth_data *outData, ODID_Auth_encoded *inEncoded);
-int decodeSelfIDMessage(ODID_SelfID_data *outData, ODID_SelfID_encoded *inEncoded);
-int decodeSystemMessage(ODID_System_data *outData, ODID_System_encoded *inEncoded);
-int decodeOperatorIDMessage(ODID_OperatorID_data *outData, ODID_OperatorID_encoded *inEncoded);
-int decodeMessagePack(ODID_UAS_Data *uasData, ODID_MessagePack_encoded *pack);
+int decodeBasicIDMessage(ODID_BasicID_data *outData, const ODID_BasicID_encoded *inEncoded);
+int decodeLocationMessage(ODID_Location_data *outData, const ODID_Location_encoded *inEncoded);
+int decodeAuthMessage(ODID_Auth_data *outData, const ODID_Auth_encoded *inEncoded);
+int decodeSelfIDMessage(ODID_SelfID_data *outData, const ODID_SelfID_encoded *inEncoded);
+int decodeSystemMessage(ODID_System_data *outData, const ODID_System_encoded *inEncoded);
+int decodeOperatorIDMessage(ODID_OperatorID_data *outData, const ODID_OperatorID_encoded *inEncoded);
+int decodeMessagePack(ODID_UAS_Data *uasData, const ODID_MessagePack_encoded *pack);
 
 int getBasicIDType(ODID_BasicID_encoded *inEncoded, enum ODID_idtype *idType);
 int getAuthPageNum(ODID_Auth_encoded *inEncoded, int *pageNum);
 ODID_messagetype_t decodeMessageType(uint8_t byte);
-ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uas_data, uint8_t *msg_data);
+ODID_messagetype_t decodeOpenDroneID(ODID_UAS_Data *uas_data, const uint8_t *msg_data);
 
 // Helper Functions
 ODID_Horizontal_accuracy_t createEnumHorizontalAccuracy(float Accuracy);
@@ -669,7 +669,7 @@ float decodeTimestampAccuracy(ODID_Timestamp_accuracy_t Accuracy);
  *
  * Returns pointer to gps_data string on success, otherwise returns NULL
  */
-void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size);
+void drone_export_gps_data(const ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size);
 
 /**
  * odid_message_build_pack - combines the messages and encodes the odid pack
@@ -680,7 +680,7 @@ void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size);
  * Returns length on success, < 0 on failure. @buf only contains a valid message
  * if the return code is >0
  */
-int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen);
+int odid_message_build_pack(const ODID_UAS_Data *UAS_Data, void *pack, size_t buflen);
 
 /* odid_wifi_build_nan_sync_beacon_frame - creates a NAN sync beacon frame
  * that shall be send just before the NAN action frame.
@@ -690,7 +690,7 @@ int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen);
  *
  * Returns the packet length on success, or < 0 on error.
  */
-int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_size);
+int odid_wifi_build_nan_sync_beacon_frame(const char *mac, uint8_t *buf, size_t buf_size);
 
 /* odid_wifi_build_message_pack_nan_action_frame - creates a message pack
  * with each type of message from the drone information into an NAN action frame.
@@ -702,7 +702,7 @@ int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_si
  *
  * Returns the packet length on success, or < 0 on error.
  */
-int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char *mac,
+int odid_wifi_build_message_pack_nan_action_frame(const ODID_UAS_Data *UAS_Data, const char *mac,
                                                   uint8_t send_counter,
                                                   uint8_t *buf, size_t buf_size);
 
@@ -719,7 +719,7 @@ int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char 
  *
  * Returns the packet length on success, or < 0 on error.
  */
-int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac,
+int odid_wifi_build_message_pack_beacon_frame(const ODID_UAS_Data *UAS_Data, const char *mac,
                                               const char *SSID, size_t SSID_len,
                                               uint16_t interval_tu, uint8_t send_counter,
                                               uint8_t *buf, size_t buf_size);
@@ -731,7 +731,7 @@ int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac
  *
  * Returns message pack length on success, or < 0 on error.
  */
-int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buflen);
+int odid_message_process_pack(ODID_UAS_Data *UAS_Data, const uint8_t *pack, size_t buflen);
 
 /* odid_wifi_receive_message_pack_nan_action_frame - processes a received message pack
  * with each type of message from the drone information into an NAN action frame
@@ -743,10 +743,10 @@ int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buf
  * Returns 0 on success, or < 0 on error. Will fill 6 bytes into @mac.
  */
 int odid_wifi_receive_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data,
-                                                    char *mac, uint8_t *buf, size_t buf_size);
+                                                    char *mac, const uint8_t *buf, size_t buf_size);
 
 #ifndef ODID_DISABLE_PRINTF
-void printByteArray(uint8_t *byteArray, uint16_t asize, int spaced);
+void printByteArray(const uint8_t *byteArray, uint16_t asize, int spaced);
 void printBasicID_data(ODID_BasicID_data *BasicID);
 void printLocation_data(ODID_Location_data *Location);
 void printAuth_data(ODID_Auth_data *Auth);

--- a/libopendroneid/wifi.c
+++ b/libopendroneid/wifi.c
@@ -138,7 +138,7 @@ static int buf_fill_ieee80211_beacon(uint8_t *buf, size_t *len, size_t buf_size,
     return 0;
 }
 
-void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
+void drone_export_gps_data(const ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
 {
     ptrdiff_t len = 0;
 
@@ -217,7 +217,7 @@ void drone_export_gps_data(ODID_UAS_Data *UAS_Data, char *buf, size_t buf_size)
     mprintf("\t}\n}");
 }
 
-int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen)
+int odid_message_build_pack(const ODID_UAS_Data *UAS_Data, void *pack, size_t buflen)
 {
     ODID_MessagePack_data msg_pack;
     ODID_MessagePack_encoded *msg_pack_enc;
@@ -286,7 +286,7 @@ int odid_message_build_pack(ODID_UAS_Data *UAS_Data, void *pack, size_t buflen)
     return (int) len;
 }
 
-int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_size)
+int odid_wifi_build_nan_sync_beacon_frame(const char *mac, uint8_t *buf, size_t buf_size)
 {
     /* Broadcast address */
     uint8_t target_addr[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
@@ -369,7 +369,7 @@ int odid_wifi_build_nan_sync_beacon_frame(char *mac, uint8_t *buf, size_t buf_si
     return (int) len;
 }
 
-int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char *mac,
+int odid_wifi_build_message_pack_nan_action_frame(const ODID_UAS_Data *UAS_Data, const char *mac,
                                                   uint8_t send_counter,
                                                   uint8_t *buf, size_t buf_size)
 {
@@ -450,7 +450,7 @@ int odid_wifi_build_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data, char 
     return (int) len;
 }
 
-int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac,
+int odid_wifi_build_message_pack_beacon_frame(const ODID_UAS_Data *UAS_Data, const char *mac,
                                               const char *SSID, size_t SSID_len,
                                               uint16_t interval_tu, uint8_t send_counter,
                                               uint8_t *buf, size_t buf_size)
@@ -532,9 +532,9 @@ int odid_wifi_build_message_pack_beacon_frame(ODID_UAS_Data *UAS_Data, char *mac
     return (int) len;
 }
 
-int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buflen)
+int odid_message_process_pack(ODID_UAS_Data *UAS_Data, const uint8_t *pack, size_t buflen)
 {
-    ODID_MessagePack_encoded *msg_pack_enc = (ODID_MessagePack_encoded *) pack;
+    const ODID_MessagePack_encoded *msg_pack_enc = (const ODID_MessagePack_encoded *) pack;
     size_t size = sizeof(*msg_pack_enc) - ODID_MESSAGE_SIZE * (ODID_PACK_MAX_MESSAGES - msg_pack_enc->MsgPackSize);
     if (size > buflen)
         return -ENOMEM;
@@ -548,7 +548,7 @@ int odid_message_process_pack(ODID_UAS_Data *UAS_Data, uint8_t *pack, size_t buf
 }
 
 int odid_wifi_receive_message_pack_nan_action_frame(ODID_UAS_Data *UAS_Data,
-                                                    char *mac, uint8_t *buf, size_t buf_size)
+                                                    char *mac, const uint8_t *buf, size_t buf_size)
 {
     struct ieee80211_mgmt *mgmt;
     struct nan_service_discovery *nsd;


### PR DESCRIPTION
Mark input pointer parameters as const to relieve API callers of needing to cast away const on input to ODID.