### PR TITLE
Update minimum required CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(opendroneid-core C)
 set(VERSION 0.2)


### PR DESCRIPTION
As of CMake 3.31.6, compatibility with CMake < 3.10 is deprecated and will be removed in a future release. To this end, in line with what has been done in #94, I propose to bump the `cmake_minimum_required` directive.