### PR TITLE
Round the encoded horizontal speed to nearest integer

### DIFF
--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -192,10 +192,10 @@ static uint8_t encodeSpeedHorizontal(float Speed_data, uint8_t *mult)
 {
     if (Speed_data <= UINT8_MAX * SPEED_DIV[0]) {
         *mult = 0;
-        return (uint8_t) (Speed_data / SPEED_DIV[0]);
+        return (uint8_t) ((Speed_data / SPEED_DIV[0]) + 0.5f);
     } else {
         *mult = 1;
-        int big_value = (int) ((Speed_data - (UINT8_MAX * SPEED_DIV[0])) / SPEED_DIV[1]);
+        int big_value = (int) (((Speed_data - (UINT8_MAX * SPEED_DIV[0])) / SPEED_DIV[1]) + 0.5f);
         return (uint8_t) intRangeMax(big_value, 0, UINT8_MAX);
     }
 }


### PR DESCRIPTION
**ASTM F3411-22a** TABLE 7, encoding table for speed has a footnote which states: _"A) Encoded Value must be rounded to nearest Integer."_.

**DIN EN 4709-002** ie the European standard says: _"*Note: encoded value shall be rounded to nearest integer."_.

Currently instead of rounding the `encodeSpeedHorizontal()` function truncates the encoded value. This leads the values being slightly off. This PR changes the behaviour to rounding by adding `0.5f` to the value before doing the integer truncate

Note that spec requires rounding only for horizontal speed. Vertical speed does not seem to require rounding.


## Current behaviour

```
63.74 / 0.25 = 254.96
254.96 truncated is 254 and 254 * 0.25 = 63.5
254.96 rounded is 255 and 255 * 0.25 is 63.75
```

The rounded version is closer to the original speed. Example roundtrip encoding and decoding.

```
ODID_Location_data odid_data;
odid_initLocationData(&odid_data);
odid_data.SpeedHorizontal = 63.74f;

ODID_Location_encoded odid_msg;
encodeLocationMessage(&odid_msg, &odid_data);

ODID_Location_data odid_data2;
decodeLocationMessage(&odid_data2, &odid_msg);

printf("%f - %f", odid_data.SpeedHorizontal, odid_data2.SpeedHorizontal);

/* Before patch: 63.74 - 63.50 */
/* After patch: 63.74 - 63.75 */
```

Another example.

```
254.24 / 0.75 = 338.9866666666667
338.9866666666667 truncated is 338 and 338 * 0.75 = 253.5
338.9866666666667 rounded is 339 and 339 * 0.75 = 254.25
```

The rounded version also is closer to the original speed. Roundtrip encoding and decoding.

```
ODID_Location_data odid_data;
odid_initLocationData(&odid_data);
odid_data.SpeedHorizontal = 254.24f;

ODID_Location_encoded odid_msg;
encodeLocationMessage(&odid_msg, &odid_data);

ODID_Location_data odid_data2;
decodeLocationMessage(&odid_data2, &odid_msg);

printf("%f - %f", odid_data.SpeedHorizontal, odid_data2.SpeedHorizontal);

/* Before patch: 254.24 - 253.50 */
/* After patch: 254.24 - 254.25 */
```