### PR TITLE
Round latitude and longitude degrees before truncating

### DIFF
--- a/libopendroneid/opendroneid.c
+++ b/libopendroneid/opendroneid.c
@@ -223,7 +223,8 @@ static int8_t encodeSpeedVertical(float SpeedVertical_data)
 */
 static int32_t encodeLatLon(double LatLon_data)
 {
-    return (int32_t) intRangeMax((int64_t) (LatLon_data * LATLON_MULT), -180 * LATLON_MULT, 180 * LATLON_MULT);
+    int64_t encoded = (int64_t) round(LatLon_data * LATLON_MULT);
+    return (int32_t) intRangeMax(encoded, -180 * LATLON_MULT, 180 * LATLON_MULT);
 }
 
 /**


### PR DESCRIPTION
Currently when doing a encode - decode roundtrip for latitude and longitude values there is sometimes a 0.0000001 degree difference between original and decoded values. This is because integer truncation discards the decimals in `encodeLatLon()`  function. **ASTM F3411-22a** mentions it requires seven decimal precision.

This PR fixes the problem by rounding the value before integer cast. Uses `round()` because `libm`  is already included elsewhere.

## Example roundtrip

```c
ODID_Location_data odid_data;
odid_initLocationData(&odid_data);
odid_data.Latitude = 51.5074000;

ODID_Location_encoded odid_msg;
encodeLocationMessage(&odid_msg, &odid_data);

ODID_Location_data odid_data2;
decodeLocationMessage(&odid_data2, &odid_msg);

printf("%.7f - %.7f", odid_data.Latitude, odid_data2.Latitude);

/* Before patch 51.5074000 - 51.5073999 */
/* After patch 51.5074000 - 51.5074000 */
```

I also tested with 0.0000001 increments and after the patch this test passes.

```c
TEST
test_latitude_incremental_range(void) {
    for (double lat = 51.0; lat <= 52.0; lat += 0.0000001) {

        ODID_Location_data odid_data;
        odid_initLocationData(&odid_data);
        odid_data.Latitude = lat;

        ODID_Location_encoded odid_msg;
        encodeLocationMessage(&odid_msg, &odid_data);

        ODID_Location_data odid_data2;
        decodeLocationMessage(&odid_data2, &odid_msg);

        printf("%.7f - %.7f", odid_data.Latitude, odid_data2.Latitude);
        printf("\n");

        /* Compare with 7 decimal precision */
        ASSERT(fabs(odid_data.Latitude - odid_data2.Latitude) < 0.00000005);

    }

    PASS();
}
```